### PR TITLE
MountLog

### DIFF
--- a/core/lib/ReactCore.rei
+++ b/core/lib/ReactCore.rei
@@ -121,7 +121,12 @@ module Make:
     /**
      * Log of operations performed to update an instance tree.
      */
-    module UpdateLog: {type entry; type t; let create: unit => t;};
+    module UpdateLog: {
+      type subtreeChange;
+      type entry;
+      type t;
+      let create: unit => t;
+    };
 
     module RenderedElement: {
       /** Type of a react element after rendering  */
@@ -149,15 +154,23 @@ module Make:
      * Log of operations performed to mount an instance tree.
      */
     module MountLog: {
-
       let mountRenderedElement:
         (Implementation.hostView, RenderedElement.t) => unit;
 
       let applyUpdateLog:
-        (Implementation.hostView, list(UpdateLog.entry)) => unit;
+        (
+          ~subtreeChange: option(UpdateLog.subtreeChange)=?,
+          Implementation.hostView,
+          list(UpdateLog.entry)
+        ) =>
+        unit;
 
       let applyTopLevelUpdate:
-        (Implementation.hostView, RenderedElement.t, option(RenderedElement.topLevelUpdate)) =>
+        (
+          Implementation.hostView,
+          RenderedElement.t,
+          option(RenderedElement.topLevelUpdate)
+        ) =>
         unit;
     };
 

--- a/core/lib/ReactCore.rei
+++ b/core/lib/ReactCore.rei
@@ -139,10 +139,16 @@ module Make:
      */
     module MountLog: {
       type entry;
-      /* type t; */
 
       let fromRenderedElement:
         (Implementation.hostView, RenderedElement.t) => list(entry);
+
+      let fromUpdateLog:
+        (Implementation.hostView, UpdateLog.t) => list(entry);
+
+      let fromTopLevelUpdate:
+        (Implementation.hostView, option(RenderedElement.topLevelUpdate)) =>
+        list(entry);
     };
 
     /**

--- a/core/lib/ReactCore.rei
+++ b/core/lib/ReactCore.rei
@@ -151,9 +151,10 @@ module Make:
     };
 
     /**
-     * Log of operations performed to mount an instance tree.
+     * Functions for mounting/unmounting an instance tree from
+     * rendered element, update log, and top level update.
      */
-    module MountLog: {
+    module HostView: {
       let mountRenderedElement:
         (Implementation.hostView, RenderedElement.t) => unit;
 

--- a/core/lib/ReactCore.rei
+++ b/core/lib/ReactCore.rei
@@ -2,6 +2,17 @@ module type HostImplementation = {
   type hostView;
   let getInstance: int => option(hostView);
   let memoizeInstance: (int, hostView) => unit;
+
+  let beginChanges: unit => unit;
+
+  let mountChild:
+    (~parent: hostView, ~child: hostView, ~position: int) => unit;
+  let unmountChild: (~parent: hostView, ~child: hostView) => unit;
+
+  let remountChild:
+    (~parent: hostView, ~child: hostView, ~position: int) => unit;
+
+  let commitChanges: unit => unit;
 };
 
 module Make:
@@ -138,17 +149,16 @@ module Make:
      * Log of operations performed to mount an instance tree.
      */
     module MountLog: {
-      type entry;
 
-      let fromRenderedElement:
-        (Implementation.hostView, RenderedElement.t) => list(entry);
+      let mountRenderedElement:
+        (Implementation.hostView, RenderedElement.t) => unit;
 
-      let fromUpdateLog:
-        (Implementation.hostView, list(UpdateLog.entry)) => list(entry);
+      let applyUpdateLog:
+        (Implementation.hostView, list(UpdateLog.entry)) => unit;
 
-      let fromTopLevelUpdate:
-        (Implementation.hostView, option(RenderedElement.topLevelUpdate)) =>
-        list(entry);
+      let applyTopLevelUpdate:
+        (Implementation.hostView, RenderedElement.t, option(RenderedElement.topLevelUpdate)) =>
+        unit;
     };
 
     /**

--- a/core/lib/ReactCore.rei
+++ b/core/lib/ReactCore.rei
@@ -159,12 +159,7 @@ module Make:
         (Implementation.hostView, RenderedElement.t) => unit;
 
       let applyUpdateLog:
-        (
-          ~subtreeChange: option(UpdateLog.subtreeChange)=?,
-          Implementation.hostView,
-          list(UpdateLog.entry)
-        ) =>
-        unit;
+        (Implementation.hostView, list(UpdateLog.entry)) => unit;
 
       let applyTopLevelUpdate:
         (

--- a/core/lib/ReactCore.rei
+++ b/core/lib/ReactCore.rei
@@ -111,6 +111,7 @@ module Make:
      * Log of operations performed to update an instance tree.
      */
     module UpdateLog: {type t; let create: unit => t;};
+
     module RenderedElement: {
       /** Type of a react element after rendering  */
       type t;
@@ -131,6 +132,17 @@ module Make:
 
       /** Flush pending state updates (and possibly add new ones). */
       let flushPendingUpdates: t => (t, UpdateLog.t);
+    };
+
+    /**
+     * Log of operations performed to mount an instance tree.
+     */
+    module MountLog: {
+      type entry;
+      /* type t; */
+
+      let fromRenderedElement:
+        (Implementation.hostView, RenderedElement.t) => list(entry);
     };
 
     /**

--- a/core/lib/ReactCore.rei
+++ b/core/lib/ReactCore.rei
@@ -110,7 +110,7 @@ module Make:
     /**
      * Log of operations performed to update an instance tree.
      */
-    module UpdateLog: {type t; let create: unit => t;};
+    module UpdateLog: {type entry; type t; let create: unit => t;};
 
     module RenderedElement: {
       /** Type of a react element after rendering  */
@@ -144,7 +144,7 @@ module Make:
         (Implementation.hostView, RenderedElement.t) => list(entry);
 
       let fromUpdateLog:
-        (Implementation.hostView, UpdateLog.t) => list(entry);
+        (Implementation.hostView, list(UpdateLog.entry)) => list(entry);
 
       let fromTopLevelUpdate:
         (Implementation.hostView, option(RenderedElement.topLevelUpdate)) =>
@@ -167,6 +167,7 @@ module Make:
       let subscribe: (~act: 'action => unit, t('action)) => unit;
 
       /** Perform an action on the subscribed component. */
+
       let act: (t('action), ~action: 'action) => unit;
     };
   };

--- a/core/lib/ReactCore_Internal.re
+++ b/core/lib/ReactCore_Internal.re
@@ -30,6 +30,8 @@ module Make = (Implementation: HostImplementation) => {
 
   module Key = {
     type t = int;
+
+    let equal = (x: t, y: t) => Pervasives.compare(x, y) == 0;
     let none = (-1);
     let dynamicKeyMagicNumber = 0;
     let create = () => {

--- a/core/lib/ReactCore_Internal.re
+++ b/core/lib/ReactCore_Internal.re
@@ -934,8 +934,11 @@ module Make = (Implementation: HostImplementation) => {
     };
   };
 
-  /** Log of operations performed to mount an instance tree. */
-  module MountLog = {
+  /**
+   * Functions for mounting/unmounting an instance tree from
+   * rendered element, update log, and top level update.
+   */
+  module HostView = {
     open Implementation;
 
     let getHostViewInstance = ({id, _}) =>

--- a/core/lib/ReactCore_Internal.re
+++ b/core/lib/ReactCore_Internal.re
@@ -41,7 +41,7 @@ module Make = (Implementation: HostImplementation) => {
   module Key = {
     type t = int;
 
-    let equal = (x: t, y: t) => Pervasives.compare(x, y) == 0;
+    let equal = (==);
     let none = (-1);
     let dynamicKeyMagicNumber = 0;
     let create = () => {
@@ -977,12 +977,12 @@ module Make = (Implementation: HostImplementation) => {
         ~f,
       ) => {
         let {id, component, subElements, instanceSubTree, _} = instance;
-        let newHostRoot =
+        let newParentHostView =
           switch (component.elementType) {
           | React => parentHostView
           | Host => f(parentHostView, id, subElements.make, position)
           };
-        traverseRenderedElement(newHostRoot, instanceSubTree, f, 0);
+        traverseRenderedElement(newParentHostView, instanceSubTree, f, 0);
       };
 
     let mountInstanceUtil =
@@ -1064,7 +1064,7 @@ module Make = (Implementation: HostImplementation) => {
         unit =
       (~subtreeChange, ~parentHostView, ~oldInstance, ~newInstance, entry) =>
         switch (entry) {
-        /* The first `Nested update means our root hasn't changed, moving on to the subtree */
+        /* The first `Nested update means our top level host view hasn't changed, moving on to the subtree */
         | `Nested => ()
         | `NoChange =>
           switch (subtreeChange) {

--- a/core/test/Assert.re
+++ b/core/test/Assert.re
@@ -119,7 +119,7 @@ let assertElement = (~label="", expected, rendered) =>
 let assertMountLog = (~label="", expected, actual) => {
   Implementation.mountLog := [];
   check(mountLog, label, expected, List.rev(actual));
-}
+};
 
 let assertUpdateLog = (~label="", expected, actual) =>
   check(updateLog, label, expected, TestRenderer.convertUpdateLog(actual));
@@ -149,7 +149,7 @@ let expectHost: type a. (~label: string=?, a, testHostItem(a)) => a =
     switch (prev) {
     | MountElement({hostRoot, renderedElement}) =>
       open TestRenderer;
-      MountLog.mountRenderedElement(hostRoot, renderedElement);
+      HostView.mountRenderedElement(hostRoot, renderedElement);
       let mountLog = Implementation.mountLog^;
       assertMountLog(~label?, expected, mountLog);
       mountLog;

--- a/core/test/Assert.re
+++ b/core/test/Assert.re
@@ -21,19 +21,19 @@ type testItem('a) =
 let renderedElement =
   Alcotest.testable(
     (formatter, t) => TestPrinter.printElement(formatter, t),
-    TestRenderer.compareElement,
+    TestRenderer.equal,
   );
 
 let topLevelUpdateLog =
   Alcotest.testable(
     (formatter, t) => TestPrinter.printTopLevelUpdateLog(formatter, t),
-    TestRenderer.compareTopLevelUpdateLog,
+    TestRenderer.equal_optionTestTopLevelUpdateLog,
   );
 
 let updateLog =
   Alcotest.testable(
     (formatter, t) => TestPrinter.printUpdateLog(formatter, t),
-    TestRenderer.compareUpdateLog,
+    TestRenderer.equal_testUpdateLog,
   );
 
 module Diff = Simple_diff.Make(String);

--- a/core/test/Assert.re
+++ b/core/test/Assert.re
@@ -19,11 +19,11 @@ type testItem('a) =
                                                   );
 
 type mountElement = {
-  hostRoot: TestRenderer.testHostInstance,
+  hostRoot: Implementation.hostView,
   renderedElement,
 };
 
-type mount = list(TestRenderer.testMountEntry);
+type mount = list(Implementation.testMountEntry);
 
 type testHostItem('a) =
   | MountElement(mountElement): testHostItem(mount);
@@ -43,7 +43,7 @@ let topLevelUpdateLog =
 let mountLog =
   Alcotest.testable(
     (formatter, t) => TestPrinter.printMountLog(formatter, t),
-    TestRenderer.equal_testMountLog,
+    Implementation.equal_testMountLog,
   );
 
 let updateLog =
@@ -116,8 +116,10 @@ let assertElement = (~label="", expected, rendered) =>
     TestRenderer.convertElement(rendered),
   );
 
-let assertMountLog = (~label="", expected, actual) =>
-  check(mountLog, label, expected, TestRenderer.convertMountLog(actual));
+let assertMountLog = (~label="", expected, actual) => {
+  Implementation.mountLog := [];
+  check(mountLog, label, expected, List.rev(actual));
+}
 
 let assertUpdateLog = (~label="", expected, actual) =>
   check(updateLog, label, expected, TestRenderer.convertUpdateLog(actual));
@@ -147,9 +149,10 @@ let expectHost: type a. (~label: string=?, a, testHostItem(a)) => a =
     switch (prev) {
     | MountElement({hostRoot, renderedElement}) =>
       open TestRenderer;
-      let mountLog = MountLog.fromRenderedElement(hostRoot, renderedElement);
+      MountLog.mountRenderedElement(hostRoot, renderedElement);
+      let mountLog = Implementation.mountLog^;
       assertMountLog(~label?, expected, mountLog);
-      TestRenderer.convertMountLog(mountLog);
+      mountLog;
     };
 
 let expect:

--- a/core/test/Components.re
+++ b/core/test/Components.re
@@ -12,7 +12,7 @@ module Box = {
     printState: _ => title,
     render: _ => {
       children: listToElement([]),
-      make: () => Implementation.Text(title),
+      make: () => Implementation.{name: "Box", element: Text(title)},
       updateInstance: (_, _) => (),
       shouldReconfigureInstance: (~oldState, ~newState) =>
         oldState != newState,
@@ -28,7 +28,7 @@ module Div = {
     ...component,
     render: _ => {
       children: listToElement(children),
-      make: () => Implementation.View,
+      make: () => Implementation.{name: "Div", element: View},
       updateInstance: (_, _) => (),
       shouldReconfigureInstance: (~oldState as _, ~newState as _) => false,
     },
@@ -55,7 +55,7 @@ module Text = {
     printState: state => state,
     render: _ => {
       children: listToElement([]),
-      make: () => Implementation.Text(title),
+      make: () => Implementation.{name: "Text", element: Text(title)},
       updateInstance: (_, _) => (),
       shouldReconfigureInstance: (~oldState, ~newState) =>
         shouldUpdate(oldState, newState),

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -31,28 +31,27 @@ let suites = [
              [<BoxWrapper id=1> twoBoxes </BoxWrapper>],
              Some({
                subtreeChange: `Nested,
-               updateLog:
-                 ref([
-                   UpdateInstance({
-                     stateChanged: false,
-                     subTreeChanged:
-                       `ReplaceElements((
-                         [<Box id=3 state="ImABox" />],
-                         [
-                           <Box id=4 state="ImABox" />,
-                           <Box id=5 state="ImABox" />,
-                         ],
-                       )),
-                     newInstance: twoBoxes,
-                     oldInstance: oneBox,
-                   }),
-                   UpdateInstance({
-                     stateChanged: false,
-                     subTreeChanged: `Nested,
-                     newInstance: <BoxWrapper id=1> twoBoxes </BoxWrapper>,
-                     oldInstance: <BoxWrapper id=1> oneBox </BoxWrapper>,
-                   }),
-                 ]),
+               updateLog: [
+                 UpdateInstance({
+                   stateChanged: false,
+                   subTreeChanged:
+                     `ReplaceElements((
+                       [<Box id=3 state="ImABox" />],
+                       [
+                         <Box id=4 state="ImABox" />,
+                         <Box id=5 state="ImABox" />,
+                       ],
+                     )),
+                   newInstance: twoBoxes,
+                   oldInstance: oneBox,
+                 }),
+                 UpdateInstance({
+                   stateChanged: false,
+                   subTreeChanged: `Nested,
+                   newInstance: <BoxWrapper id=1> twoBoxes </BoxWrapper>,
+                   oldInstance: <BoxWrapper id=1> oneBox </BoxWrapper>,
+                 }),
+               ],
              }),
            ),
          )
@@ -80,17 +79,16 @@ let suites = [
              [<ChangeCounter id=1 label="updated text" counter=1 />],
              Some({
                subtreeChange: `Nested,
-               updateLog:
-                 ref([
-                   UpdateInstance({
-                     stateChanged: true,
-                     subTreeChanged: `NoChange,
-                     oldInstance:
-                       <ChangeCounter id=1 label="default text" counter=0 />,
-                     newInstance:
-                       <ChangeCounter id=1 label="updated text" counter=1 />,
-                   }),
-                 ]),
+               updateLog: [
+                 UpdateInstance({
+                   stateChanged: true,
+                   subTreeChanged: `NoChange,
+                   oldInstance:
+                     <ChangeCounter id=1 label="default text" counter=0 />,
+                   newInstance:
+                     <ChangeCounter id=1 label="updated text" counter=1 />,
+                 }),
+               ],
              }),
            ),
          )
@@ -144,25 +142,21 @@ let suites = [
                [<ButtonWrapperWrapper id=2 nestedText="initial text" />],
                Some({
                  subtreeChange: `Nested,
-                 updateLog:
-                   ref([
-                     ChangeComponent({
-                       oldSubtree: [],
-                       newSubtree: [
-                         <Div id=3>
-                           <Text id=4 title="initial text" />
-                           <ButtonWrapper id=5 />
-                         </Div>,
-                       ],
-                       oldInstance:
-                         <ChangeCounter id=1 label="default text" counter=0 />,
-                       newInstance:
-                         <ButtonWrapperWrapper
-                           id=2
-                           nestedText="initial text"
-                         />,
-                     }),
-                   ]),
+                 updateLog: [
+                   ChangeComponent({
+                     oldSubtree: [],
+                     newSubtree: [
+                       <Div id=3>
+                         <Text id=4 title="initial text" />
+                         <ButtonWrapper id=5 />
+                       </Div>,
+                     ],
+                     oldInstance:
+                       <ChangeCounter id=1 label="default text" counter=0 />,
+                     newInstance:
+                       <ButtonWrapperWrapper id=2 nestedText="initial text" />,
+                   }),
+                 ],
                }),
              ),
            );
@@ -177,43 +171,36 @@ let suites = [
                [<ButtonWrapperWrapper id=2 nestedText="updated text" />],
                Some({
                  subtreeChange: `Nested,
-                 updateLog:
-                   ref([
-                     UpdateInstance({
-                       stateChanged: true,
-                       subTreeChanged: `ContentChanged(`NoChange),
-                       oldInstance: <Text id=4 title="initial text" />,
-                       newInstance: <Text id=4 title="updated text" />,
-                     }),
-                     UpdateInstance({
-                       stateChanged: false,
-                       subTreeChanged: `Nested,
-                       oldInstance:
-                         <Div id=3>
-                           <Text id=4 title="initial text" />
-                           <ButtonWrapper id=5 />
-                         </Div>,
-                       newInstance:
-                         <Div id=3>
-                           <Text id=4 title="updated text" />
-                           <ButtonWrapper id=5 />
-                         </Div>,
-                     }),
-                     UpdateInstance({
-                       stateChanged: false,
-                       subTreeChanged: `Nested,
-                       oldInstance:
-                         <ButtonWrapperWrapper
-                           id=2
-                           nestedText="initial text"
-                         />,
-                       newInstance:
-                         <ButtonWrapperWrapper
-                           id=2
-                           nestedText="updated text"
-                         />,
-                     }),
-                   ]),
+                 updateLog: [
+                   UpdateInstance({
+                     stateChanged: true,
+                     subTreeChanged: `ContentChanged(`NoChange),
+                     oldInstance: <Text id=4 title="initial text" />,
+                     newInstance: <Text id=4 title="updated text" />,
+                   }),
+                   UpdateInstance({
+                     stateChanged: false,
+                     subTreeChanged: `Nested,
+                     oldInstance:
+                       <Div id=3>
+                         <Text id=4 title="initial text" />
+                         <ButtonWrapper id=5 />
+                       </Div>,
+                     newInstance:
+                       <Div id=3>
+                         <Text id=4 title="updated text" />
+                         <ButtonWrapper id=5 />
+                       </Div>,
+                   }),
+                   UpdateInstance({
+                     stateChanged: false,
+                     subTreeChanged: `Nested,
+                     oldInstance:
+                       <ButtonWrapperWrapper id=2 nestedText="initial text" />,
+                     newInstance:
+                       <ButtonWrapperWrapper id=2 nestedText="updated text" />,
+                   }),
+                 ],
                }),
              ),
            );
@@ -482,7 +469,7 @@ let suites = [
                        <BoxItemDynamic id=1 state="box to move" />,
                      ],
                    )),
-                 updateLog: ref([]),
+                 updateLog: [],
                }),
              ),
            );
@@ -531,21 +518,20 @@ let suites = [
              ],
              Some({
                subtreeChange: `Reordered,
-               updateLog:
-                 ref([
-                   UpdateInstance({
-                     stateChanged: true,
-                     subTreeChanged: `ContentChanged(`NoChange),
-                     oldInstance: <Box id=1 state="Box1unchanged" />,
-                     newInstance: <Box id=1 state="Box1changed" />,
-                   }),
-                   UpdateInstance({
-                     stateChanged: true,
-                     subTreeChanged: `ContentChanged(`NoChange),
-                     oldInstance: <Box id=2 state="Box2unchanged" />,
-                     newInstance: <Box id=2 state="Box2changed" />,
-                   }),
-                 ]),
+               updateLog: [
+                 UpdateInstance({
+                   stateChanged: true,
+                   subTreeChanged: `ContentChanged(`NoChange),
+                   oldInstance: <Box id=1 state="Box1unchanged" />,
+                   newInstance: <Box id=1 state="Box1changed" />,
+                 }),
+                 UpdateInstance({
+                   stateChanged: true,
+                   subTreeChanged: `ContentChanged(`NoChange),
+                   oldInstance: <Box id=2 state="Box2unchanged" />,
+                   newInstance: <Box id=2 state="Box2changed" />,
+                 }),
+               ],
              }),
            ),
          )
@@ -658,7 +644,7 @@ let suites = [
                    [<Text id=1 title="x" />],
                    [<Text id=2 title="y" />],
                  )),
-               updateLog: ref([]),
+               updateLog: [],
              }),
            ),
          )
@@ -694,21 +680,20 @@ let suites = [
              [<Text id=1 title="x" />, <Text id=2 title="y" />],
              Some({
                subtreeChange: `Nested,
-               updateLog:
-                 ref([
-                   UpdateInstance({
-                     stateChanged: true,
-                     subTreeChanged: `NoChange,
-                     oldInstance: <Text id=2 title="y" />,
-                     newInstance: <Text id=2 title="y" />,
-                   }),
-                   UpdateInstance({
-                     stateChanged: true,
-                     subTreeChanged: `NoChange,
-                     oldInstance: <Text id=1 title="x" />,
-                     newInstance: <Text id=1 title="x" />,
-                   }),
-                 ]),
+               updateLog: [
+                 UpdateInstance({
+                   stateChanged: true,
+                   subTreeChanged: `NoChange,
+                   oldInstance: <Text id=2 title="y" />,
+                   newInstance: <Text id=2 title="y" />,
+                 }),
+                 UpdateInstance({
+                   stateChanged: true,
+                   subTreeChanged: `NoChange,
+                   oldInstance: <Text id=1 title="x" />,
+                   newInstance: <Text id=1 title="x" />,
+                 }),
+               ],
              }),
            ),
          )
@@ -727,21 +712,20 @@ let suites = [
              [<Text id=2 title="y" />, <Text id=1 title="x" />],
              Some({
                subtreeChange: `Reordered,
-               updateLog:
-                 ref([
-                   UpdateInstance({
-                     stateChanged: true,
-                     subTreeChanged: `NoChange,
-                     oldInstance: <Text id=1 title="x" />,
-                     newInstance: <Text id=1 title="x" />,
-                   }),
-                   UpdateInstance({
-                     stateChanged: true,
-                     subTreeChanged: `NoChange,
-                     oldInstance: <Text id=2 title="y" />,
-                     newInstance: <Text id=2 title="y" />,
-                   }),
-                 ]),
+               updateLog: [
+                 UpdateInstance({
+                   stateChanged: true,
+                   subTreeChanged: `NoChange,
+                   oldInstance: <Text id=1 title="x" />,
+                   newInstance: <Text id=1 title="x" />,
+                 }),
+                 UpdateInstance({
+                   stateChanged: true,
+                   subTreeChanged: `NoChange,
+                   oldInstance: <Text id=2 title="y" />,
+                   newInstance: <Text id=2 title="y" />,
+                 }),
+               ],
              }),
            ),
          )
@@ -773,7 +757,7 @@ let suites = [
              [<Text id=2 title="y" />, <Text id=1 title="x" />],
              Some({
                subtreeChange: `PrependElement([<Text id=2 title="y" />]),
-               updateLog: ref([]),
+               updateLog: [],
              }),
            ),
          )

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -922,8 +922,8 @@ let mountLog = [
         ~label="It correctly mounts `Reordered topLevelUpdate",
         [
           Implementation.BeginChanges,
-          RemountChild(root, {name: "Text", element: Text("x")}, 0),
           RemountChild(root, {name: "Text", element: Text("y")}, 0),
+          RemountChild(root, {name: "Text", element: Text("x")}, 1),
           CommitChanges,
         ],
         Implementation.mountLog^,

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -4,7 +4,7 @@ open TestRenderer;
 
 open Assert;
 
-let suites = [
+let core = [
   (
     "Test simple subtree change",
     `Quick,
@@ -55,7 +55,7 @@ let suites = [
              }),
            ),
          )
-      |> done_;
+      |> ignore;
     },
   ),
   (
@@ -120,7 +120,7 @@ let suites = [
            ~label="It flushes updates, but there are no pending actions",
            None,
          )
-      |> done_,
+      |> ignore,
   ),
   (
     "Test changing components",
@@ -329,7 +329,7 @@ let suites = [
              ],
            )),
          )
-      |> done_;
+      |> ignore;
     },
   ),
   (
@@ -428,7 +428,7 @@ let suites = [
              ],
            )),
          )
-      |> done_;
+      |> ignore;
     },
   ),
   (
@@ -535,7 +535,7 @@ let suites = [
              }),
            ),
          )
-      |> done_;
+      |> ignore;
     },
   ),
   (
@@ -624,7 +624,7 @@ let suites = [
              ],
            )),
          )
-      |> done_;
+      |> ignore;
     },
   ),
   (
@@ -648,7 +648,7 @@ let suites = [
              }),
            ),
          )
-      |> done_,
+      |> ignore,
   ),
   (
     "Test no change",
@@ -729,7 +729,7 @@ let suites = [
              }),
            ),
          )
-      |> done_;
+      |> ignore;
     },
   ),
   (
@@ -761,7 +761,67 @@ let suites = [
              }),
            ),
          )
-      |> done_;
+      |> ignore;
+    },
+  ),
+];
+
+let mountLog = [
+  (
+    "Test rendered element mount",
+    `Quick,
+    () => {
+      let root = Implementation.{name: "root", element: View};
+
+      TestRenderer.render(<Components.BoxWrapper />)
+      |> mount(root)
+      |> expectHost(
+           ~label=
+             "It correctly prepares a mount log, ignoring non-native BoxWrapper",
+           [
+             MountChild(
+               {name: "root", element: View},
+               {name: "Div", element: View},
+             ),
+             MountChild(
+               {name: "Div", element: View},
+               {name: "Box", element: Text("ImABox")},
+             ),
+           ],
+         )
+      |> ignore;
+    },
+  ),
+  (
+    "Test child elements list mount",
+    `Quick,
+    () => {
+      let root = Implementation.{name: "root", element: View};
+
+      TestRenderer.render(
+        Components.(
+          <Div> <Box title="ImABox1" /> <Box title="ImABox2" /> </Div>
+        ),
+      )
+      |> mount(root)
+      |> expectHost(
+           ~label="It mounts two moxes in a div",
+           [
+             MountChild(
+               {name: "root", element: View},
+               {name: "Div", element: View},
+             ),
+             MountChild(
+               {name: "Div", element: View},
+               {name: "Box", element: Text("ImABox1")},
+             ),
+             MountChild(
+               {name: "Div", element: View},
+               {name: "Box", element: Text("ImABox2")},
+             ),
+           ],
+         )
+      |> ignore;
     },
   ),
 ];
@@ -769,4 +829,8 @@ let suites = [
 /** Annoying dune progress */
 print_endline("");
 
-Alcotest.run(~argv=[|"--verbose --color"|], "Brisk", [("Core", suites)]);
+Alcotest.run(
+  ~argv=[|"--verbose --color"|],
+  "Brisk",
+  [("Core", core), ("MountLog", mountLog)],
+);

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -900,8 +900,7 @@ let mountLog = [
       let _ = MountLog.mountRenderedElement(root, beforeUpdate);
 
       assertMountLog(
-        ~label=
-          "It correctly mounts top level list with static keys (for reorder)",
+        ~label="It correctly mounts top level list (for reorder)",
         [
           Implementation.BeginChanges,
           MountChild(root, {name: "Text", element: Text("x")}, 0),
@@ -962,7 +961,7 @@ let mountLog = [
 
       MountLog.applyTopLevelUpdate(root, afterUpdate, topLevelUpdateLog);
       assertMountLog(
-        ~label="It correctly mounts `Reordered topLevelUpdate",
+        ~label="It correctly mounts `ReplaceElements topLevelUpdate",
         [
           Implementation.BeginChanges,
           UnmountChild(root, {name: "Text", element: Text("x")}),
@@ -995,8 +994,7 @@ let mountLog = [
       let _ = MountLog.mountRenderedElement(root, beforeUpdate);
 
       assertMountLog(
-        ~label=
-          "It correctly mounts top level list with static keys (for prepend)",
+        ~label="It correctly mounts top level list (for prepend)",
         [
           Implementation.BeginChanges,
           MountChild(root, {name: "Text", element: Text("x")}, 0),

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -846,7 +846,7 @@ let mountLog = [
       let nextReactElement = Components.(<Div> <Box title="ImABox3" /> </Div>);
 
       let beforeUpdate = TestRenderer.render(previousReactElement);
-      let _ = MountLog.mountRenderedElement(root, beforeUpdate);
+      let _ = HostView.mountRenderedElement(root, beforeUpdate);
       Implementation.mountLog := [];
 
       let (afterUpdate, topLevelUpdateLog) =
@@ -856,7 +856,7 @@ let mountLog = [
           nextReactElement,
         );
 
-      MountLog.applyTopLevelUpdate(root, afterUpdate, topLevelUpdateLog);
+      HostView.applyTopLevelUpdate(root, afterUpdate, topLevelUpdateLog);
       assertMountLog(
         ~label="It correctly mounts topLevelUpdate",
         [
@@ -897,7 +897,7 @@ let mountLog = [
         );
 
       let beforeUpdate = TestRenderer.render(previousReactElement);
-      let _ = MountLog.mountRenderedElement(root, beforeUpdate);
+      let _ = HostView.mountRenderedElement(root, beforeUpdate);
 
       assertMountLog(
         ~label="It correctly mounts top level list (for reorder)",
@@ -917,7 +917,7 @@ let mountLog = [
           nextReactElement,
         );
 
-      MountLog.applyTopLevelUpdate(root, afterUpdate, topLevelUpdateLog);
+      HostView.applyTopLevelUpdate(root, afterUpdate, topLevelUpdateLog);
       assertMountLog(
         ~label="It correctly mounts `Reordered topLevelUpdate",
         [
@@ -940,7 +940,7 @@ let mountLog = [
       let nextReactElement = <Components.Text key=2 title="y" />;
 
       let beforeUpdate = TestRenderer.render(previousReactElement);
-      let _ = MountLog.mountRenderedElement(root, beforeUpdate);
+      let _ = HostView.mountRenderedElement(root, beforeUpdate);
 
       assertMountLog(
         ~label="It correctly mounts top level element (for replace elemets)",
@@ -959,7 +959,7 @@ let mountLog = [
           nextReactElement,
         );
 
-      MountLog.applyTopLevelUpdate(root, afterUpdate, topLevelUpdateLog);
+      HostView.applyTopLevelUpdate(root, afterUpdate, topLevelUpdateLog);
       assertMountLog(
         ~label="It correctly mounts `ReplaceElements topLevelUpdate",
         [
@@ -991,7 +991,7 @@ let mountLog = [
         ]);
 
       let beforeUpdate = TestRenderer.render(previousReactElement);
-      let _ = MountLog.mountRenderedElement(root, beforeUpdate);
+      let _ = HostView.mountRenderedElement(root, beforeUpdate);
 
       assertMountLog(
         ~label="It correctly mounts top level list (for prepend)",
@@ -1010,7 +1010,7 @@ let mountLog = [
           nextReactElement,
         );
 
-      MountLog.applyTopLevelUpdate(root, afterUpdate, topLevelUpdateLog);
+      HostView.applyTopLevelUpdate(root, afterUpdate, topLevelUpdateLog);
       assertMountLog(
         ~label="It correctly mounts `Prepend topLevelUpdate",
         [

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -824,6 +824,40 @@ let mountLog = [
       |> ignore;
     },
   ),
+  (
+    "Test element update top level mount",
+    `Quick,
+    () => {
+      let root = Implementation.{name: "root", element: View};
+
+      let previousReactElement =
+        Components.(
+          <Div> <Box title="ImABox1" /> <Box title="ImABox2" /> </Div>
+        );
+      let nextReactElement = Components.(<Div> <Box title="ImABox3" /> </Div>);
+
+      let beforeUpdate = TestRenderer.render(previousReactElement);
+      let _ = MountLog.fromRenderedElement(root, beforeUpdate);
+
+      let (afterUpdate, topLevelUpdateLog) =
+        RenderedElement.update(
+          ~previousReactElement,
+          ~renderedElement=beforeUpdate,
+          nextReactElement,
+        );
+
+      let mountLog = MountLog.fromTopLevelUpdate(root, topLevelUpdateLog);
+      assertMountLog(
+        ~label="It correctly mounts topLevelUpdate",
+        [
+          UnmountChild(root, {name: "Box", element: Text("ImABox1")}),
+          UnmountChild(root, {name: "Box", element: Text("ImABox2")}),
+          MountChild(root, {name: "Box", element: Text("ImABox3")}),
+        ],
+        mountLog,
+      );
+    },
+  ),
 ];
 
 /** Annoying dune progress */

--- a/core/test/TestPrinter.re
+++ b/core/test/TestPrinter.re
@@ -41,24 +41,39 @@ let rec formatInstance = instance => {
 let formatElement = instances =>
   List(("[", "", "]", list), instances |> List.map(formatInstance));
 
-let formatMountLogItem =
+let formatMountLogItem = TestReactCore.Implementation.(
   fun
-  | MountChild(root, child) =>
+  | BeginChanges =>
+    Atom("BeginChanges", atom)
+  | CommitChanges =>
+    Atom("CommitChanges", atom)
+  | MountChild(root, child, position) =>
     List(
       ("MountChild (", ",", ")", list),
       [
-        makeField("root", Atom(show_testHostInstance(root), atom)),
-        makeField("child", Atom(show_testHostInstance(child), atom)),
+        makeField("root", Atom(show_hostView(root), atom)),
+        makeField("child", Atom(show_hostView(child), atom)),
+        makeField("position", Atom(string_of_int(position), atom)),
       ],
     )
   | UnmountChild(root, child) =>
     List(
       ("UnmountChild (", ",", ")", list),
       [
-        makeField("root", Atom(show_testHostInstance(root), atom)),
-        makeField("child", Atom(show_testHostInstance(child), atom)),
+        makeField("root", Atom(show_hostView(root), atom)),
+        makeField("child", Atom(show_hostView(child), atom)),
       ],
-    );
+    )
+  | RemountChild(root, child, position) =>
+    List(
+      ("RemountChild (", ",", ")", list),
+      [
+        makeField("root", Atom(show_hostView(root), atom)),
+        makeField("child", Atom(show_hostView(child), atom)),
+        makeField("position", Atom(string_of_int(position), atom)),
+      ],
+    )
+);
 
 let formatMountLog = mountLog =>
   List(("[", ",", "]", list), mountLog |> List.map(formatMountLogItem));

--- a/core/test/TestPrinter.re
+++ b/core/test/TestPrinter.re
@@ -41,6 +41,28 @@ let rec formatInstance = instance => {
 let formatElement = instances =>
   List(("[", "", "]", list), instances |> List.map(formatInstance));
 
+let formatMountLogItem =
+  fun
+  | MountChild(root, child) =>
+    List(
+      ("MountChild (", ",", ")", list),
+      [
+        makeField("root", Atom(show_testHostInstance(root), atom)),
+        makeField("child", Atom(show_testHostInstance(child), atom)),
+      ],
+    )
+  | UnmountChild(root, child) =>
+    List(
+      ("UnmountChild (", ",", ")", list),
+      [
+        makeField("root", Atom(show_testHostInstance(root), atom)),
+        makeField("child", Atom(show_testHostInstance(child), atom)),
+      ],
+    );
+
+let formatMountLog = mountLog =>
+  List(("[", ",", "]", list), mountLog |> List.map(formatMountLogItem));
+
 let formatSubTreeChangeReact =
   fun
   | `Reordered => Atom("`Reordered", atom)
@@ -105,6 +127,9 @@ let formatTopLevelUpdateLog =
 
 let printElement = (formatter, instances) =>
   Pretty.to_formatter(formatter, formatElement(instances));
+
+let printMountLog = (formatter, mountLog) =>
+  Pretty.to_formatter(formatter, formatMountLog(mountLog));
 
 let printUpdateLog = (formatter, updateLog) =>
   Pretty.to_formatter(formatter, formatUpdateLog(updateLog));

--- a/core/test/TestPrinter.re
+++ b/core/test/TestPrinter.re
@@ -41,39 +41,38 @@ let rec formatInstance = instance => {
 let formatElement = instances =>
   List(("[", "", "]", list), instances |> List.map(formatInstance));
 
-let formatMountLogItem = TestReactCore.Implementation.(
-  fun
-  | BeginChanges =>
-    Atom("BeginChanges", atom)
-  | CommitChanges =>
-    Atom("CommitChanges", atom)
-  | MountChild(root, child, position) =>
-    List(
-      ("MountChild (", ",", ")", list),
-      [
-        makeField("root", Atom(show_hostView(root), atom)),
-        makeField("child", Atom(show_hostView(child), atom)),
-        makeField("position", Atom(string_of_int(position), atom)),
-      ],
-    )
-  | UnmountChild(root, child) =>
-    List(
-      ("UnmountChild (", ",", ")", list),
-      [
-        makeField("root", Atom(show_hostView(root), atom)),
-        makeField("child", Atom(show_hostView(child), atom)),
-      ],
-    )
-  | RemountChild(root, child, position) =>
-    List(
-      ("RemountChild (", ",", ")", list),
-      [
-        makeField("root", Atom(show_hostView(root), atom)),
-        makeField("child", Atom(show_hostView(child), atom)),
-        makeField("position", Atom(string_of_int(position), atom)),
-      ],
-    )
-);
+let formatMountLogItem =
+  TestReactCore.Implementation.(
+    fun
+    | BeginChanges => Atom("BeginChanges", atom)
+    | CommitChanges => Atom("CommitChanges", atom)
+    | MountChild(root, child, position) =>
+      List(
+        ("MountChild (", ",", ")", list),
+        [
+          makeField("root", Atom(show_hostView(root), atom)),
+          makeField("child", Atom(show_hostView(child), atom)),
+          makeField("position", Atom(string_of_int(position), atom)),
+        ],
+      )
+    | UnmountChild(root, child) =>
+      List(
+        ("UnmountChild (", ",", ")", list),
+        [
+          makeField("root", Atom(show_hostView(root), atom)),
+          makeField("child", Atom(show_hostView(child), atom)),
+        ],
+      )
+    | RemountChild(root, child, position) =>
+      List(
+        ("RemountChild (", ",", ")", list),
+        [
+          makeField("root", Atom(show_hostView(root), atom)),
+          makeField("child", Atom(show_hostView(child), atom)),
+          makeField("position", Atom(string_of_int(position), atom)),
+        ],
+      )
+  );
 
 let formatMountLog = mountLog =>
   List(("[", ",", "]", list), mountLog |> List.map(formatMountLogItem));

--- a/core/test/TestPrinter.re
+++ b/core/test/TestPrinter.re
@@ -13,6 +13,12 @@ let makeProp = (key, value) =>
 let makeField = (key, value) =>
   Label((Atom(key ++ ":", atom), field), value);
 
+let componentName = component =>
+  switch (component) {
+  | InstanceAndComponent(component, _) => component.debugName
+  | Component(component) => component.debugName
+  };
+
 let rec formatInstance = instance => {
   let tag = componentName(instance.component);
   switch (instance.subtree) {
@@ -93,7 +99,7 @@ let formatTopLevelUpdateLog =
       ("TopLevelUpdate {", ",", "}", list),
       [
         makeField("subTreeChange", formatSubTreeChange(update.subtreeChange)),
-        makeField("updateLog", formatUpdateLog(update.updateLog^)),
+        makeField("updateLog", formatUpdateLog(update.updateLog)),
       ],
     );
 

--- a/core/test/TestReactCore.re
+++ b/core/test/TestReactCore.re
@@ -12,7 +12,20 @@ module Implementation = {
     element: hostElement,
   };
 
+  [@deriving eq]
+  type testMountEntry =
+    | BeginChanges
+    | CommitChanges
+    | MountChild(hostView, hostView, int)
+    | UnmountChild(hostView, hostView)
+    | RemountChild(hostView, hostView, int);
+
+  [@deriving eq]
+  type testMountLog = list(testMountEntry);
+
   let map: Hashtbl.t(int, hostView) = Hashtbl.create(1000);
+
+  let mountLog = ref([]);
 
   let getInstance = id =>
     if (Hashtbl.mem(map, id)) {
@@ -21,6 +34,28 @@ module Implementation = {
       None;
     };
   let memoizeInstance = (id, instance) => Hashtbl.add(map, id, instance);
+
+  let beginChanges = () => {
+    mountLog := [BeginChanges, ...mountLog^];
+  };
+
+  let commitChanges = () => {
+    mountLog := [CommitChanges, ...mountLog^];
+  };
+
+  let mountChild =
+    (~parent: hostView, ~child: hostView, ~position: int) => {
+      mountLog := [MountChild(parent, child, position), ...mountLog^];
+  };
+
+  let unmountChild = (~parent: hostView, ~child: hostView) => {
+    mountLog := [UnmountChild(parent, child), ...mountLog^];
+  };
+
+  let remountChild =
+  (~parent: hostView, ~child: hostView, ~position: int) => {
+    mountLog := [RemountChild(parent, child, position), ...mountLog^];
+  };
 };
 
 include ReactCore_Internal.Make(Implementation);

--- a/core/test/TestReactCore.re
+++ b/core/test/TestReactCore.re
@@ -35,27 +35,18 @@ module Implementation = {
     };
   let memoizeInstance = (id, instance) => Hashtbl.add(map, id, instance);
 
-  let beginChanges = () => {
-    mountLog := [BeginChanges, ...mountLog^];
-  };
+  let beginChanges = () => mountLog := [BeginChanges, ...mountLog^];
 
-  let commitChanges = () => {
-    mountLog := [CommitChanges, ...mountLog^];
-  };
+  let commitChanges = () => mountLog := [CommitChanges, ...mountLog^];
 
-  let mountChild =
-    (~parent: hostView, ~child: hostView, ~position: int) => {
-      mountLog := [MountChild(parent, child, position), ...mountLog^];
-  };
+  let mountChild = (~parent: hostView, ~child: hostView, ~position: int) =>
+    mountLog := [MountChild(parent, child, position), ...mountLog^];
 
-  let unmountChild = (~parent: hostView, ~child: hostView) => {
+  let unmountChild = (~parent: hostView, ~child: hostView) =>
     mountLog := [UnmountChild(parent, child), ...mountLog^];
-  };
 
-  let remountChild =
-  (~parent: hostView, ~child: hostView, ~position: int) => {
+  let remountChild = (~parent: hostView, ~child: hostView, ~position: int) =>
     mountLog := [RemountChild(parent, child, position), ...mountLog^];
-  };
 };
 
 include ReactCore_Internal.Make(Implementation);

--- a/core/test/TestReactCore.re
+++ b/core/test/TestReactCore.re
@@ -1,10 +1,19 @@
 open Brisk_core;
 
 module Implementation = {
-  type hostView =
+  [@deriving (show({with_path: false}), eq)]
+  type hostElement =
     | Text(string)
     | View;
+
+  [@deriving (show({with_path: false}), eq)]
+  type hostView = {
+    name: string,
+    element: hostElement,
+  };
+
   let map: Hashtbl.t(int, hostView) = Hashtbl.create(1000);
+
   let getInstance = id =>
     if (Hashtbl.mem(map, id)) {
       Some(Hashtbl.find(map, id));

--- a/core/test/TestRenderer.re
+++ b/core/test/TestRenderer.re
@@ -4,14 +4,42 @@ type opaqueComponent =
   | Component(componentSpec('a, 'b, 'c, 'd)): opaqueComponent
   | InstanceAndComponent(component('a, 'b, 'c), instance('a, 'b, 'c)): opaqueComponent;
 
+let equal_opaqueComponent = (left, right) =>
+  switch (left, right) {
+  | (Component(_), Component(_))
+  | (InstanceAndComponent(_, _), InstanceAndComponent(_, _)) =>
+    assert(false)
+  | (Component(justComponent), InstanceAndComponent(comp, instance)) =>
+    comp.handedOffInstance := Some((instance, instance));
+    let result =
+      switch (justComponent.handedOffInstance^) {
+      | Some(_) => true
+      | None => false
+      };
+    comp.handedOffInstance := None;
+    result;
+  | (InstanceAndComponent(comp, instance), Component(justComponent)) =>
+    comp.handedOffInstance := Some((instance, instance));
+    let result =
+      switch (justComponent.handedOffInstance^) {
+      | Some(_) => true
+      | None => false
+      };
+    comp.handedOffInstance := None;
+    result;
+  };
+
+[@deriving eq]
 type testInstance = {
   component: opaqueComponent,
   id: Key.t,
   subtree: t,
   state: string,
 }
+[@deriving eq]
 and t = list(testInstance);
 
+[@deriving eq]
 type testSubTreeChangeReact = [
   | `NoChange
   | `Nested
@@ -20,11 +48,13 @@ type testSubTreeChangeReact = [
   | `ReplaceElements(t, t)
 ];
 
+[@deriving eq]
 type testSubTreeChange = [
   testSubTreeChangeReact
   | `ContentChanged(testSubTreeChangeReact)
 ];
 
+[@deriving eq]
 type testUpdate = {
   oldInstance: testInstance,
   newInstance: testInstance,
@@ -32,6 +62,7 @@ type testUpdate = {
   subTreeChanged: testSubTreeChange,
 };
 
+[@deriving eq]
 type testChangeComponent = {
   oldInstance: testInstance,
   newInstance: testInstance,
@@ -39,16 +70,22 @@ type testChangeComponent = {
   newSubtree: t,
 };
 
+[@deriving eq]
 type testUpdateEntry =
   | UpdateInstance(testUpdate)
   | ChangeComponent(testChangeComponent);
 
-type testUpdateLog = ref(list(testUpdateEntry));
+[@deriving eq]
+type testUpdateLog = list(testUpdateEntry);
 
+[@deriving eq]
 type testTopLevelUpdateLog = {
   subtreeChange: testSubTreeChange,
   updateLog: testUpdateLog,
 };
+
+[@deriving eq]
+type optionTestTopLevelUpdateLog = option(testTopLevelUpdateLog);
 
 let rec convertInstance:
   'state 'action 'elementType .
@@ -133,107 +170,6 @@ let convertTopLevelUpdateLog:
   | Some(topLevelUpdate) =>
     Some({
       subtreeChange: convertSubTreeChange(topLevelUpdate.subtreeChange),
-      updateLog:
-        ref(convertUpdateLog(topLevelUpdate.RenderedElement.updateLog)),
+      updateLog: convertUpdateLog(topLevelUpdate.RenderedElement.updateLog),
     })
   | None => None;
-
-let compareComponents = (left, right) =>
-  switch (left, right) {
-  | (Component(_), Component(_))
-  | (InstanceAndComponent(_, _), InstanceAndComponent(_, _)) =>
-    assert(false)
-  | (Component(justComponent), InstanceAndComponent(comp, instance)) =>
-    comp.handedOffInstance := Some((instance, instance));
-    let result =
-      switch (justComponent.handedOffInstance^) {
-      | Some(_) => true
-      | None => false
-      };
-    comp.handedOffInstance := None;
-    result;
-  | (InstanceAndComponent(comp, instance), Component(justComponent)) =>
-    comp.handedOffInstance := Some((instance, instance));
-    let result =
-      switch (justComponent.handedOffInstance^) {
-      | Some(_) => true
-      | None => false
-      };
-    comp.handedOffInstance := None;
-    result;
-  };
-
-let rec compareElement = (left, right) =>
-  switch (left, right) {
-  | (le, re) =>
-    if (List.length(le) != List.length(re)) {
-      false;
-    } else {
-      List.fold_left(
-        (&&),
-        true,
-        List.map(compareInstance, List.combine(le, re)),
-      );
-    }
-  }
-and compareInstance = ((left, right)) =>
-  left.id == right.id
-  && left.state == right.state
-  && compareComponents(left.component, right.component)
-  && compareElement(left.subtree, right.subtree);
-
-let compareSubtreeReact =
-  fun
-  | (`NoChange, `NoChange)
-  | (`Nested, `Nested)
-  | (`Reordered, `Reordered) => true
-  | (`PrependElement(left), `PrependElement(right)) =>
-    compareElement(left, right)
-  | (`ReplaceElements(left1, left2), `ReplaceElements(right1, right2)) =>
-    compareElement(left1, right1) && compareElement(left2, right2)
-  | (_, _) => false;
-
-let compareSubtree =
-  fun
-  | (`ContentChanged(x), `ContentChanged(y)) => compareSubtreeReact((x, y))
-  | (#testSubTreeChangeReact, #testSubTreeChangeReact) as x =>
-    compareSubtreeReact(x)
-  | (_, _) => false;
-
-let rec compareUpdateLog = (left, right) =>
-  switch (left, right) {
-  | ([], []) => true
-  | ([UpdateInstance(x), ...t1], [UpdateInstance(y), ...t2]) =>
-    x.stateChanged === y.stateChanged
-    && compareSubtree((x.subTreeChanged, y.subTreeChanged))
-    && compareUpdateLog(t1, t2)
-    && compareInstance((x.oldInstance, y.oldInstance))
-    && compareInstance((x.newInstance, y.newInstance))
-  | ([ChangeComponent(x), ...t1], [ChangeComponent(y), ...t2]) =>
-    compareElement(x.oldSubtree, y.oldSubtree)
-    && compareElement(x.newSubtree, y.newSubtree)
-    && compareInstance((x.oldInstance, y.oldInstance))
-    && compareInstance((x.newInstance, y.newInstance))
-    && compareUpdateLog(t1, t2)
-  | ([UpdateInstance(_), ..._], [_, ..._])
-  | ([ChangeComponent(_), ..._], [_, ..._])
-  | ([_, ..._], [])
-  | ([], [_, ..._]) => false
-  };
-
-let compareTopLevelUpdateLog:
-  (option(testTopLevelUpdateLog), option(testTopLevelUpdateLog)) => bool =
-  (left, right) =>
-    switch (left, right) {
-    | (None, None) => true
-    | (Some(x), Some(y)) =>
-      compareSubtree((x.subtreeChange, y.subtreeChange))
-      && compareUpdateLog(x.updateLog^, y.updateLog^)
-    | (_, _) => false
-    };
-
-let componentName = component =>
-  switch (component) {
-  | InstanceAndComponent(component, _) => component.debugName
-  | Component(component) => component.debugName
-  };

--- a/core/test/TestRenderer.re
+++ b/core/test/TestRenderer.re
@@ -39,21 +39,6 @@ type testInstance = {
 [@deriving eq]
 and t = list(testInstance);
 
-type hostElement =
-  | Text(string)
-  | View;
-
-[@deriving (show({with_path: false}), eq)]
-type testHostInstance = Implementation.hostView;
-
-[@deriving eq]
-type testMountEntry =
-  | MountChild(testHostInstance, testHostInstance)
-  | UnmountChild(testHostInstance, testHostInstance);
-
-[@deriving eq]
-type testMountLog = list(testMountEntry);
-
 [@deriving eq]
 type testSubTreeChangeReact = [
   | `NoChange
@@ -138,18 +123,6 @@ let convertSubTreeChange =
   | `ReplaceElements(_, _) as x => convertSubTreeChangeReact(x);
 
 let render = element => RenderedElement.render(element);
-
-let rec convertMountLog =
-  fun
-  | [] => []
-  | [MountLog.MountChild(root, child), ...t] => [
-      MountChild(root, child),
-      ...convertMountLog(t),
-    ]
-  | [MountLog.UnmountChild(root, child), ...t] => [
-      UnmountChild(root, child),
-      ...convertMountLog(t),
-    ];
 
 let convertUpdateLog = (updateLog: UpdateLog.t) => {
   let rec convertUpdateLog = (updateLogRef: list(UpdateLog.entry)) =>

--- a/core/test/TestRenderer.re
+++ b/core/test/TestRenderer.re
@@ -39,6 +39,21 @@ type testInstance = {
 [@deriving eq]
 and t = list(testInstance);
 
+type hostElement =
+  | Text(string)
+  | View;
+
+[@deriving (show({with_path: false}), eq)]
+type testHostInstance = Implementation.hostView;
+
+[@deriving eq]
+type testMountEntry =
+  | MountChild(testHostInstance, testHostInstance)
+  | UnmountChild(testHostInstance, testHostInstance);
+
+[@deriving eq]
+type testMountLog = list(testMountEntry);
+
 [@deriving eq]
 type testSubTreeChangeReact = [
   | `NoChange
@@ -123,6 +138,18 @@ let convertSubTreeChange =
   | `ReplaceElements(_, _) as x => convertSubTreeChangeReact(x);
 
 let render = element => RenderedElement.render(element);
+
+let rec convertMountLog =
+  fun
+  | [] => []
+  | [MountLog.MountChild(root, child), ...t] => [
+      MountChild(root, child),
+      ...convertMountLog(t),
+    ]
+  | [MountLog.UnmountChild(root, child), ...t] => [
+      UnmountChild(root, child),
+      ...convertMountLog(t),
+    ];
 
 let convertUpdateLog = (updateLog: UpdateLog.t) => {
   let rec convertUpdateLog = (updateLogRef: list(UpdateLog.entry)) =>

--- a/core/test/jbuild
+++ b/core/test/jbuild
@@ -2,7 +2,9 @@
 
 (executables
  ((names (test))
-  (libraries (alcotest easy-format simple-diff brisk_core))))
+  (libraries (alcotest easy-format simple-diff brisk_core))
+  (preprocess (pps (ppx_deriving.std)))
+ ))
 
 (alias
  ((name runtest)

--- a/esy.json
+++ b/esy.json
@@ -11,17 +11,18 @@
   "scripts": {
     "test": "esy jbuilder runtest --no-buffer"
   },
+  "dependencies": {
+    "@esy-ocaml/esy-installer": "^0.0.0",
+    "@esy-ocaml/reason": "^3.2.0",
+    "@opam/jbuilder": "^1.0.0-beta20",
+    "@opam/ppx_deriving": "^4.2.1",
+    "flex": "briskml/flex#b0f7a43",
+    "refmterr": "^3.1.7"
+  },
   "resolutions": {
     "**/@opam/result": "1.2.0",
     "**/@opam/lwt": "3.3.0",
     "**/@opam/ocaml-migrate-parsetree": "1.0.10"
-  },
-  "dependencies": {
-    "@esy-ocaml/esy-installer": "^0.0.0",
-    "@esy-ocaml/reason": "facebook/reason#3629912",
-    "@opam/jbuilder": "^1.0.0-beta20",
-    "flex": "briskml/flex#b0f7a43",
-    "refmterr": "^3.1.7"
   },
   "peerDependencies": {
     "ocaml": "~4.6.1"

--- a/esy.json
+++ b/esy.json
@@ -9,7 +9,8 @@
     "buildsInSource": "_build"
   },
   "scripts": {
-    "test": "esy jbuilder runtest --no-buffer"
+    "build:dev": "refmterr jbuilder build --dev",
+    "test": "jbuilder runtest --no-buffer"
   },
   "dependencies": {
     "@esy-ocaml/esy-installer": "^0.0.0",

--- a/esy.json
+++ b/esy.json
@@ -14,26 +14,21 @@
     "test": "refmterr jbuilder runtest --no-buffer"
   },
   "dependencies": {
-    "@esy-ocaml/esy-installer": "^0.0.0",
-    "@esy-ocaml/reason": "^3.2.0",
-    "@opam/jbuilder": "^1.0.0-beta20",
+    "@esy-ocaml/esy-installer": "*",
+    "@esy-ocaml/reason": "^3.3.0",
+    "@opam/jbuilder": "*",
     "@opam/ppx_deriving": "^4.2.1",
-    "flex": "briskml/flex#b0f7a43",
+    "flex": "briskml/flex#21dc063",
     "refmterr": "^3.1.7"
   },
-  "resolutions": {
-    "**/@opam/result": "1.2.0",
-    "**/@opam/lwt": "3.3.0",
-    "**/@opam/ocaml-migrate-parsetree": "1.0.10"
-  },
   "peerDependencies": {
-    "ocaml": "~4.6.1"
+    "ocaml": "~4.6.4"
   },
   "devDependencies": {
     "@esy-ocaml/merlin": "^3.0.5",
     "@opam/alcotest": "^0.8.3",
     "@opam/easy-format": "^1.3.1",
-    "@opam/simple-diff": "^0.3.0",
-    "ocaml": "~4.6.1"
+    "@opam/simple-diff": "0.3",
+    "ocaml": "~4.6.4"
   }
 }

--- a/esy.json
+++ b/esy.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build:dev": "refmterr jbuilder build --dev",
-    "test": "jbuilder runtest --no-buffer"
+    "clean": "jbuilder clean",
+    "test": "refmterr jbuilder runtest --no-buffer"
   },
   "dependencies": {
     "@esy-ocaml/esy-installer": "^0.0.0",

--- a/esy.lock
+++ b/esy.lock
@@ -7,8 +7,8 @@
   resolved "https://registry.yarnpkg.com/@esy-ocaml/esy-installer/-/esy-installer-0.0.0.tgz#6b0e2bd4ee43531ac74793fe55cfcc3aca197a66"
 
 "@esy-ocaml/merlin@^3.0.5":
-  version "3.0.5004"
-  resolved "https://registry.yarnpkg.com/@esy-ocaml/merlin/-/merlin-3.0.5004.tgz#e92a1cb8448b230874837dcf7da29def41f46170"
+  version "3.0.5005"
+  resolved "https://registry.yarnpkg.com/@esy-ocaml/merlin/-/merlin-3.0.5005.tgz#4a9e2b4df20672524603b7b1797b7761d5d0d9ad"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -17,9 +17,9 @@
   peerDependencies:
     ocaml " >= 4.2.1  < 4.7.0"
 
-"@esy-ocaml/reason@^3.0.0", "@esy-ocaml/reason@facebook/reason#3629912":
-  version "3.1.0"
-  resolved "https://codeload.github.com/facebook/reason/tar.gz/36299129efb1b15eaad357c6d35b0e407e8f04b6"
+"@esy-ocaml/reason@^3.0.0", "@esy-ocaml/reason@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@esy-ocaml/reason/-/reason-3.2.0.tgz#9b68a6649f3ba38a11a0fdc7b7c004cab512ac8e"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -27,12 +27,8 @@
     "@opam/menhir" " >= 20170418.0.0  <= 20171013.0.0"
     "@opam/merlin-extend" " >= 0.3.0"
     "@opam/ocaml-migrate-parsetree" "*"
-    "@opam/ocamlbuild" "*"
     "@opam/ocamlfind" ""
     "@opam/result" "*"
-    "@opam/utop" " >= 1.17.0"
-  peerDependencies:
-    ocaml " >= 4.2.0  < 4.7.0"
 
 "@esy-ocaml/substs@^0.0.1":
   version "0.0.1"
@@ -78,16 +74,6 @@
   peerDependencies:
     ocaml " >= 4.2.0"
 
-"@opam/base-threads@*":
-  version "0.0.0-base"
-  uid "5601b815938b487242834ca2ddd7e3fc"
-  resolved "@opam/base-threads@0.0.0-base-5601b815938b487242834ca2ddd7e3fc.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-  peerDependencies:
-    ocaml "*"
-
 "@opam/base-unix@*":
   version "0.0.0-base"
   uid "04bc004c59f2edca849d38ea6891bb7f"
@@ -108,29 +94,6 @@
     "@opam/conf-which" "*"
     "@opam/easy-format" "*"
     "@opam/jbuilder" " >= 1.0.0-beta7"
-  peerDependencies:
-    ocaml " >= 4.2.3000"
-
-"@opam/camlp4@*":
-  version "4.6.0-1"
-  uid ec9e71b1e73d101ab8ef9a66cc9035e7
-  resolved "@opam/camlp4@4.6.0-1-ec9e71b1e73d101ab8ef9a66cc9035e7.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/ocamlbuild" "*"
-  peerDependencies:
-    ocaml " >= 4.6.0  < 4.7.0"
-
-"@opam/camomile@ >= 0.8.0", "@opam/camomile@ >= 0.8.6", "@opam/camomile@*":
-  version "1.0.1"
-  uid f4d58fb782e0362b7848320ac26890de
-  resolved "@opam/camomile@1.0.1-f4d58fb782e0362b7848320ac26890de.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/camlp4" "*"
-    "@opam/jbuilder" " >= 1.0.0-beta17"
   peerDependencies:
     ocaml " >= 4.2.3000"
 
@@ -168,7 +131,7 @@
   peerDependencies:
     ocaml "*"
 
-"@opam/cppo@ >= 1.1.0", "@opam/cppo@ >= 1.1.2", "@opam/cppo@*":
+"@opam/cppo@ >= 1.1.0", "@opam/cppo@ >= 1.6.0", "@opam/cppo@*":
   version "1.6.4"
   uid "0caf37d16727e17fbcd4e9b41a467f91"
   resolved "@opam/cppo@1.6.4-0caf37d16727e17fbcd4e9b41a467f91.tgz"
@@ -178,6 +141,19 @@
     "@opam/base-bytes" "*"
     "@opam/base-unix" "*"
     "@opam/jbuilder" " >= 1.0.0-beta17"
+  peerDependencies:
+    ocaml "*"
+
+"@opam/cppo_ocamlbuild@*":
+  version "1.6.0"
+  uid "76c36d0e895b7ef5a207f158d017d4da"
+  resolved "@opam/cppo_ocamlbuild@1.6.0-76c36d0e895b7ef5a207f158d017d4da.tgz"
+  dependencies:
+    "@esy-ocaml/esy-installer" "^0.0.0"
+    "@esy-ocaml/substs" "^0.0.1"
+    "@opam/cppo" " >= 1.6.0"
+    "@opam/jbuilder" " >= 1.0.0-beta10"
+    "@opam/ocamlbuild" "*"
   peerDependencies:
     ocaml "*"
 
@@ -194,8 +170,8 @@
 
 "@opam/fmt@ >= 0.8.0":
   version "0.8.5"
-  uid "5c1870ebd5137354d253a3abbaf020f0"
-  resolved "@opam/fmt@0.8.5-5c1870ebd5137354d253a3abbaf020f0.tgz"
+  uid e11ffecd1ece76196e4274a6567b935c
+  resolved "@opam/fmt@0.8.5-e11ffecd1ece76196e4274a6567b935c.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -207,7 +183,7 @@
   peerDependencies:
     ocaml " >= 4.1.0"
 
-"@opam/jbuilder@ >= 1.0.0-beta10", "@opam/jbuilder@ >= 1.0.0-beta14", "@opam/jbuilder@ >= 1.0.0-beta17", "@opam/jbuilder@ >= 1.0.0-beta181", "@opam/jbuilder@ >= 1.0.0-beta7", "@opam/jbuilder@ >= 1.0.0-beta9", "@opam/jbuilder@*", "@opam/jbuilder@^1.0.0-beta14", "@opam/jbuilder@^1.0.0-beta20":
+"@opam/jbuilder@ >= 1.0.0-beta10", "@opam/jbuilder@ >= 1.0.0-beta14", "@opam/jbuilder@ >= 1.0.0-beta17", "@opam/jbuilder@ >= 1.0.0-beta181", "@opam/jbuilder@ >= 1.0.0-beta7", "@opam/jbuilder@*", "@opam/jbuilder@^1.0.0-beta14", "@opam/jbuilder@^1.0.0-beta20":
   version "1.0.0-beta20"
   uid "1648206284a54407f6eee01ed950fff7"
   resolved "@opam/jbuilder@1.0.0-beta20-1648206284a54407f6eee01ed950fff7.tgz"
@@ -218,26 +194,10 @@
   peerDependencies:
     ocaml " >= 4.2.3000"
 
-"@opam/lambda-term@ >= 1.2.0":
-  version "1.12.0"
-  uid "318456db287041f877e89e7098a12312"
-  resolved "@opam/lambda-term@1.12.0-318456db287041f877e89e7098a12312.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/camomile" " >= 0.8.6"
-    "@opam/jbuilder" " >= 1.0.0-beta9"
-    "@opam/lwt" " >= 2.7.0  < 4.0.0"
-    "@opam/lwt_react" "*"
-    "@opam/react" "*"
-    "@opam/zed" " >= 1.2.0"
-  peerDependencies:
-    ocaml " >= 4.2.3000"
-
-"@opam/lwt@ >= 2.7.0  < 4.0.0", "@opam/lwt@ >= 3.0.0", "@opam/lwt@*", "@opam/lwt@3.3.0":
+"@opam/lwt@3.3.0":
   version "3.3.0"
-  uid d6527433462fadf2f1b8168dbb5cf10e
-  resolved "@opam/lwt@3.3.0-d6527433462fadf2f1b8168dbb5cf10e.tgz"
+  uid "7a557303c8bfd71515f716b5429733b0"
+  resolved "@opam/lwt@3.3.0-7a557303c8bfd71515f716b5429733b0.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -249,19 +209,6 @@
     "@opam/result" "*"
   peerDependencies:
     ocaml " >= 4.2.0"
-
-"@opam/lwt_react@*":
-  version "1.1.1"
-  uid aa9053f8fd0e2684a474b8dbcc0a30d6
-  resolved "@opam/lwt_react@1.1.1-aa9053f8fd0e2684a474b8dbcc0a30d6.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta14"
-    "@opam/lwt" " >= 3.0.0"
-    "@opam/react" " >= 1.0.0"
-  peerDependencies:
-    ocaml "*"
 
 "@opam/menhir@ >= 20170418.0.0  <= 20171013.0.0":
   version "20171013.0.0"
@@ -310,7 +257,7 @@
   peerDependencies:
     ocaml " >= 4.3.0"
 
-"@opam/ocamlfind@", "@opam/ocamlfind@ >= 1.5.0", "@opam/ocamlfind@ >= 1.5.2", "@opam/ocamlfind@ >= 1.5.3", "@opam/ocamlfind@ >= 1.6.1", "@opam/ocamlfind@ >= 1.7.2", "@opam/ocamlfind@ >= 1.7.3--1", "@opam/ocamlfind@*":
+"@opam/ocamlfind@", "@opam/ocamlfind@ >= 1.5.0", "@opam/ocamlfind@ >= 1.5.2", "@opam/ocamlfind@ >= 1.5.3", "@opam/ocamlfind@ >= 1.6.0", "@opam/ocamlfind@ >= 1.6.1", "@opam/ocamlfind@ >= 1.7.3--1", "@opam/ocamlfind@*":
   version "1.8.0"
   uid "525500c3041431ef23d0f7d1895c8b9a"
   resolved "@opam/ocamlfind@1.8.0-525500c3041431ef23d0f7d1895c8b9a.tgz"
@@ -320,6 +267,46 @@
     "@opam/conf-m4" "*"
   peerDependencies:
     ocaml " >= 4.0.0"
+
+"@opam/ppx_derivers@*":
+  version "1.0.0"
+  uid "8f34e516ed653f2d9d6fbae0d01e64d8"
+  resolved "@opam/ppx_derivers@1.0.0-8f34e516ed653f2d9d6fbae0d01e64d8.tgz"
+  dependencies:
+    "@esy-ocaml/esy-installer" "^0.0.0"
+    "@esy-ocaml/substs" "^0.0.1"
+    "@opam/jbuilder" " >= 1.0.0-beta7"
+  peerDependencies:
+    ocaml "*"
+
+"@opam/ppx_deriving@^4.2.1":
+  version "4.2.1"
+  uid "25184a5ac3bcba32981d0f83f1f03614"
+  resolved "@opam/ppx_deriving@4.2.1-25184a5ac3bcba32981d0f83f1f03614.tgz"
+  dependencies:
+    "@esy-ocaml/esy-installer" "^0.0.0"
+    "@esy-ocaml/substs" "^0.0.1"
+    "@opam/cppo" "*"
+    "@opam/cppo_ocamlbuild" "*"
+    "@opam/ocaml-migrate-parsetree" "*"
+    "@opam/ocamlbuild" "*"
+    "@opam/ocamlfind" " >= 1.6.0"
+    "@opam/ppx_derivers" "*"
+    "@opam/ppx_tools" " >= 4.2.3"
+    "@opam/result" "*"
+  peerDependencies:
+    ocaml " > 4.3.0"
+
+"@opam/ppx_tools@ >= 4.2.3":
+  version "5.1.0-4060"
+  uid "5d5943b6bcf3ea32ebf346e8f9097cea"
+  resolved "@opam/ppx_tools@5.1.0-4060-5d5943b6bcf3ea32ebf346e8f9097cea.tgz"
+  dependencies:
+    "@esy-ocaml/esy-installer" "^0.0.0"
+    "@esy-ocaml/substs" "^0.0.1"
+    "@opam/ocamlfind" " >= 1.5.0"
+  peerDependencies:
+    ocaml " >= 4.6.0  < 4.8.0"
 
 "@opam/ppx_tools_versioned@ >= 5.0.1":
   version "5.1.0"
@@ -343,19 +330,6 @@
     "@opam/jbuilder" " >= 1.0.0-beta10"
   peerDependencies:
     ocaml " >= 4.2.3000"
-
-"@opam/react@ >= 1.0.0", "@opam/react@*":
-  version "1.2.1"
-  uid "719921829ec3b46cecefeeaefcb6cb61"
-  resolved "@opam/react@1.2.1-719921829ec3b46cecefeeaefcb6cb61.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/ocamlbuild" "*"
-    "@opam/ocamlfind" "*"
-    "@opam/topkg" " >= 0.9.0"
-  peerDependencies:
-    ocaml " >= 4.1.0"
 
 "@opam/result@*", "@opam/result@1.2.0":
   version "1.2.0"
@@ -405,26 +379,6 @@
   peerDependencies:
     ocaml " >= 3.12.0"
 
-"@opam/utop@ >= 1.17.0":
-  version "2.1.0"
-  uid "52ddf36354cf7530843a68ffd29ed6ac"
-  resolved "@opam/utop@2.1.0-52ddf36354cf7530843a68ffd29ed6ac.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/base-threads" "*"
-    "@opam/base-unix" "*"
-    "@opam/camomile" "*"
-    "@opam/cppo" " >= 1.1.2"
-    "@opam/jbuilder" " >= 1.0.0-beta9"
-    "@opam/lambda-term" " >= 1.2.0"
-    "@opam/lwt" "*"
-    "@opam/lwt_react" "*"
-    "@opam/ocamlfind" " >= 1.7.2"
-    "@opam/react" " >= 1.0.0"
-  peerDependencies:
-    ocaml " >= 4.2.3000"
-
 "@opam/yojson@*":
   version "1.4.1"
   uid "1d23ddc5148ccb2ca2e11f0a854d35dd"
@@ -436,20 +390,6 @@
     "@opam/cppo" "*"
     "@opam/easy-format" "*"
     "@opam/jbuilder" "*"
-  peerDependencies:
-    ocaml " >= 4.2.3000"
-
-"@opam/zed@ >= 1.2.0":
-  version "1.6.0"
-  uid "9a4c3157c2db719927f9648234487c6d"
-  resolved "@opam/zed@1.6.0-9a4c3157c2db719927f9648234487c6d.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/base-bytes" "*"
-    "@opam/camomile" " >= 0.8.0"
-    "@opam/jbuilder" " >= 1.0.0-beta9"
-    "@opam/react" "*"
   peerDependencies:
     ocaml " >= 4.2.3000"
 

--- a/esyi.lock.json
+++ b/esyi.lock.json
@@ -1,0 +1,713 @@
+{
+  "hash": "843597254ec9816da32ea2395ddd14b6",
+  "root": "brisk@path:.",
+  "node": {
+    "refmterr@3.1.7": {
+      "record": {
+        "name": "refmterr",
+        "version": "3.1.7",
+        "source":
+          "archive:https://registry.npmjs.org/refmterr/-/refmterr-3.1.7.tgz#sha1:fdd6a58e212b18c6a0685ff21f27a7df6621b3e8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "@esy-ocaml/reason@3.3.0", "@opam/jbuilder@opam:transition",
+        "@opam/re@opam:1.7.3"
+      ]
+    },
+    "ocaml@4.6.4": {
+      "record": {
+        "name": "ocaml",
+        "version": "4.6.4",
+        "source":
+          "archive:https://registry.npmjs.org/ocaml/-/ocaml-4.6.4.tgz#sha1:315bc4f8231b605674306715ce362dfaf42fee2c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "flex@github:briskml/flex#21dc063": {
+      "record": {
+        "name": "flex",
+        "version": "github:briskml/flex#21dc063",
+        "source": "github:briskml/flex#21dc063",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/reason@3.3.0",
+        "@opam/jbuilder@opam:transition", "refmterr@3.1.7"
+      ]
+    },
+    "brisk@path:.": {
+      "record": {
+        "name": "brisk",
+        "version": "path:.",
+        "source": "path:.",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/merlin@3.0.5005",
+        "@esy-ocaml/reason@3.3.0", "@opam/alcotest@opam:0.8.3",
+        "@opam/easy-format@opam:1.3.1", "@opam/jbuilder@opam:transition",
+        "@opam/ppx_deriving@opam:4.2.1", "@opam/simple-diff@opam:0.3",
+        "flex@github:briskml/flex#21dc063", "ocaml@4.6.4", "refmterr@3.1.7"
+      ]
+    },
+    "@opam/yojson@opam:1.4.1": {
+      "record": {
+        "name": "@opam/yojson",
+        "version": "opam:1.4.1",
+        "source":
+          "archive:https://github.com/mjambon/yojson/archive/v1.4.1.tar.gz#md5:3ea6e36422dd670e8ab880710d5f7398",
+        "files": [],
+        "opam": {
+          "name": "yojson",
+          "version": "1.4.1",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"martin@mjambon.com\"\nauthors: \"Martin Jambon\"\nhomepage: \"http://mjambon.com/yojson.html\"\nbug-reports: \"https://github.com/mjambon/yojson/issues\"\ndepends: [\n  \"jbuilder\" {build}\n  \"cppo\" {build}\n  \"easy-format\"\n  \"biniou\" {>= \"1.2.0\"}\n]\navailable: ocaml-version >= \"4.02.3\"\nbuild: [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\nrun-test: [\"jbuilder\" \"runtest\" \"-p\" name]\ndev-repo: \"git+https://github.com/mjambon/yojson.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/biniou@opam:1.2.0", "@opam/cppo@opam:1.6.4",
+        "@opam/easy-format@opam:1.3.1", "@opam/jbuilder@opam:transition"
+      ]
+    },
+    "@opam/uchar@opam:0.0.2": {
+      "record": {
+        "name": "@opam/uchar",
+        "version": "opam:0.0.2",
+        "source":
+          "archive:https://github.com/ocaml/uchar/releases/download/v0.0.2/uchar-0.0.2.tbz#md5:c9ba2c738d264c420c642f7bb1cf4a36",
+        "files": [],
+        "opam": {
+          "name": "uchar",
+          "version": "0.0.2",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"Daniel Bünzli <daniel.buenzl i@erratique.ch>\"\nauthors: \"Daniel Bünzli <daniel.buenzl i@erratique.ch>\"\nlicense: \"typeof OCaml system\"\ntags: [\"text\" \"character\" \"unicode\" \"compatibility\" \"org:ocaml.org\"]\nhomepage: \"http://ocaml.org\"\ndoc: \"https://ocaml.github.io/uchar/\"\nbug-reports: \"https://github.com/ocaml/uchar/issues\"\ndepends: [\n  \"ocamlbuild\" {build}\n]\navailable: ocaml-version >= \"3.12.0\"\nbuild: [\n  [\"ocaml\" \"pkg/git.ml\"]\n  [\n    \"ocaml\"\n    \"pkg/build.ml\"\n    \"native=%{ocaml-native}%\"\n    \"native-dynlink=%{ocaml-native-dynlink}%\"\n  ]\n]\ndev-repo: \"git+https://github.com/ocaml/uchar.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/ocamlbuild@opam:0.12.0"
+      ]
+    },
+    "@opam/topkg@opam:0.9.1": {
+      "record": {
+        "name": "@opam/topkg",
+        "version": "opam:0.9.1",
+        "source":
+          "archive:http://erratique.ch/software/topkg/releases/topkg-0.9.1.tbz#md5:8978a0595db1a22e4251ec62735d4b84",
+        "files": [],
+        "opam": {
+          "name": "topkg",
+          "version": "0.9.1",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"Daniel Bünzli <daniel.buenzl i@erratique.ch>\"\nauthors: \"Daniel Bünzli <daniel.buenzl i@erratique.ch>\"\nlicense: \"ISC\"\ntags: [\"packaging\" \"ocamlbuild\" \"org:erratique\"]\nhomepage: \"http://erratique.ch/software/topkg\"\ndoc: \"http://erratique.ch/software/topkg/doc\"\nbug-reports: \"https://github.com/dbuenzli/topkg/issues\"\ndepends: [\n  \"ocamlfind\" {build & >= \"1.6.1\"}\n  \"ocamlbuild\"\n  \"result\"\n]\navailable: ocaml-version >= \"4.01.0\"\nbuild: [\n  \"ocaml\" \"pkg/pkg.ml\" \"build\" \"--pkg-name\" name \"--dev-pkg\" \"%{pinned}%\"\n]\ndev-repo: \"git+http://erratique.ch/repos/topkg.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/ocamlbuild@opam:0.12.0", "@opam/ocamlfind@opam:1.8.0",
+        "@opam/result@opam:1.3"
+      ]
+    },
+    "@opam/simple-diff@opam:0.3": {
+      "record": {
+        "name": "@opam/simple-diff",
+        "version": "opam:0.3",
+        "source":
+          "archive:https://github.com/gjaldon/simple-diff/archive/v0.3.tar.gz#md5:4751d72fe03c4b3cc45ad6476bcbe558",
+        "files": [],
+        "opam": {
+          "name": "simple-diff",
+          "version": "0.3",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"Gabriel Jaldon <gjaldon85@gmail.com>\"\nauthors: \"Gabriel Jaldon\"\nlicense: \"ISC\"\nhomepage: \"https://github.com/gjaldon/simple_diff\"\ndoc: \"https://gjaldon.github.io/simple-diff/\"\nbug-reports: \"https://github.com/gjaldon/simple_diff/issues\"\ndepends: [\n  \"topkg\" {build}\n  \"ocamlfind\" {build}\n  \"ocamlbuild\" {build}\n  \"re\" {>= \"1.7.1\"}\n]\navailable: ocaml-version >= \"4.00.0\"\nbuild: [\"ocaml\" \"pkg/pkg.ml\" \"build\" \"--pinned\" \"%{pinned}%\"]\ndev-repo: \"git+https://github.com/gjaldon/simple_diff.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/ocamlbuild@opam:0.12.0", "@opam/ocamlfind@opam:1.8.0",
+        "@opam/re@opam:1.7.3", "@opam/topkg@opam:0.9.1"
+      ]
+    },
+    "@opam/result@opam:1.3": {
+      "record": {
+        "name": "@opam/result",
+        "version": "opam:1.3",
+        "source":
+          "archive:https://github.com/janestreet/result/releases/download/1.3/result-1.3.tbz#md5:4beebefd41f7f899b6eeba7414e7ae01",
+        "files": [],
+        "opam": {
+          "name": "result",
+          "version": "1.3",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"opensource@janestreet.com\"\nauthors: \"Jane Street Group, LLC <opensource@janestreet.com>\"\nlicense: \"BSD3\"\nhomepage: \"https://github.com/janestreet/result\"\nbug-reports: \"https://github.com/janestreet/result/issues\"\ndepends: [\n  \"jbuilder\" {build & >= \"1.0+beta11\"}\n]\nbuild: [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\ndev-repo: \"git+https://github.com/janestreet/result.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/jbuilder@opam:transition"
+      ]
+    },
+    "@opam/re@opam:1.7.3": {
+      "record": {
+        "name": "@opam/re",
+        "version": "opam:1.7.3",
+        "source":
+          "archive:https://github.com/ocaml/ocaml-re/releases/download/1.7.3/re-1.7.3.tbz#md5:d2a74ca77216861bce4449600a132de9",
+        "files": [],
+        "opam": {
+          "name": "re",
+          "version": "1.7.3",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"rudi.grinberg@gmail.com\"\nauthors: [\n  \"Jerome Vouillon\"\n  \"Thomas Gazagnaire\"\n  \"Anil Madhavapeddy\"\n  \"Rudi Grinberg\"\n  \"Gabriel Radanne\"\n]\nlicense: \"LGPL-2.0 with OCaml linking exception\"\nhomepage: \"https://github.com/ocaml/ocaml-re\"\nbug-reports: \"https://github.com/ocaml/ocaml-re/issues\"\ndepends: [\n  \"jbuilder\" {build & >= \"1.0+beta10\"}\n  \"ounit\" {test}\n]\navailable: ocaml-version >= \"4.02.3\"\nbuild: [\n  [\"jbuilder\" \"subst\" \"-p\" name] {pinned}\n  [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\n]\nrun-test: [\"jbuilder\" \"runtest\" \"-p\" name \"-j\" jobs]\ndev-repo: \"git+https://github.com/ocaml/ocaml-re.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/jbuilder@opam:transition"
+      ]
+    },
+    "@opam/ppx_tools@opam:5.1+4.06.0": {
+      "record": {
+        "name": "@opam/ppx_tools",
+        "version": "opam:5.1+4.06.0",
+        "source":
+          "archive:https://github.com/ocaml-ppx/ppx_tools/archive/5.1+4.06.0.tar.gz#md5:6ba2e9690b1f579ba562b86022d1c308",
+        "files": [],
+        "opam": {
+          "name": "ppx_tools",
+          "version": "5.1+4.06.0",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"alain.frisch@lexifi.com\"\nauthors: \"Alain Frisch <alain.frisch@lexifi.com>\"\nlicense: \"MIT\"\ntags: \"syntax\"\nhomepage: \"https://github.com/ocaml-ppx/ppx_tools\"\nbug-reports: \"https://github.com/ocaml-ppx/ppx_tools/issues\"\ndepends: [\n  \"ocamlfind\" {>= \"1.5.0\"}\n]\navailable: ocaml-version >= \"4.06.0\" & ocaml-version < \"4.08\"\nbuild: [make \"all\"]\ninstall: [make \"install\"]\nremove: [\"ocamlfind\" \"remove\" \"ppx_tools\"]\ndev-repo: \"git://github.com/ocaml-ppx/ppx_tools.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/ocamlfind@opam:1.8.0"
+      ]
+    },
+    "@opam/ppx_deriving@opam:4.2.1": {
+      "record": {
+        "name": "@opam/ppx_deriving",
+        "version": "opam:4.2.1",
+        "source":
+          "archive:https://github.com/ocaml-ppx/ppx_deriving/archive/v4.2.1.tar.gz#md5:2195fccf2a527c3ff9ec5b4e36e2f0a8",
+        "files": [],
+        "opam": {
+          "name": "ppx_deriving",
+          "version": "4.2.1",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"whitequark <whitequark@whitequark.org>\"\nauthors: \"whitequark <whitequark@whitequark.org>\"\nlicense: \"MIT\"\ntags: \"syntax\"\nhomepage: \"https://github.com/whitequark/ppx_deriving\"\ndoc: \"https://whitequark.github.io/ppx_deriving\"\nbug-reports: \"https://github.com/whitequark/ppx_deriving/issues\"\ndepends: [\n  \"ocamlbuild\" {build}\n  \"ocamlfind\" {build & >= \"1.6.0\"}\n  \"cppo\" {build}\n  \"cppo_ocamlbuild\" {build}\n  \"ocaml-migrate-parsetree\"\n  \"ppx_derivers\"\n  \"ppx_tools\" {>= \"4.02.3\"}\n  \"result\"\n  \"ounit\" {test}\n]\navailable: ocaml-version > \"4.03.0\" & opam-version >= \"1.2\"\nbuild: [\n  \"ocaml\"\n  \"pkg/build.ml\"\n  \"native=%{ocaml-native-dynlink}%\"\n  \"native-dynlink=%{ocaml-native-dynlink}%\"\n]\nrun-test: [\n  \"ocamlbuild\"\n  \"-classic-display\"\n  \"-use-ocamlfind\"\n  \"src_test/test_ppx_deriving.byte\"\n  \"--\"\n]\nsubsts: \"pkg/META\"\ndev-repo: \"git+https://github.com/whitequark/ppx_deriving.git\"\nbuild-doc: [make \"doc\"]",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/cppo@opam:1.6.4", "@opam/cppo_ocamlbuild@opam:1.6.0",
+        "@opam/ocaml-migrate-parsetree@opam:1.0.11",
+        "@opam/ocamlbuild@opam:0.12.0", "@opam/ocamlfind@opam:1.8.0",
+        "@opam/ppx_derivers@opam:1.0", "@opam/ppx_tools@opam:5.1+4.06.0",
+        "@opam/result@opam:1.3"
+      ]
+    },
+    "@opam/ppx_derivers@opam:1.0": {
+      "record": {
+        "name": "@opam/ppx_derivers",
+        "version": "opam:1.0",
+        "source":
+          "archive:https://github.com/ocaml-ppx/ppx_derivers/archive/1.0.tar.gz#md5:4ddce8f43fdb9b0ef0ab6a7cbfebc3e3",
+        "files": [],
+        "opam": {
+          "name": "ppx_derivers",
+          "version": "1.0",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"jeremie@dimino.org\"\nauthors: \"Jérémie Dimino\"\nlicense: \"BSD3\"\nhomepage: \"https://github.com/ocaml-ppx/ppx_derivers\"\nbug-reports: \"https://github.com/ocaml-ppx/ppx_derivers/issues\"\ndepends: [\n  \"jbuilder\" {build & >= \"1.0+beta7\"}\n]\nbuild: [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\ndev-repo: \"git://github.com/ocaml-ppx/ppx_derivers.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/jbuilder@opam:transition"
+      ]
+    },
+    "@opam/ocamlfind@opam:1.8.0": {
+      "record": {
+        "name": "@opam/ocamlfind",
+        "version": "opam:1.8.0",
+        "source":
+          "archive:http://download.camlcity.org/download/findlib-1.8.0.tar.gz#md5:a710c559667672077a93d34eb6a42e5b",
+        "files": [
+          {
+            "name": "ocaml-stub",
+            "content":
+              "#!/bin/sh\n\nBINDIR=$(dirname \"$(command -v ocamlc)\")\n\"$BINDIR/ocaml\" -I \"$OCAML_TOPLEVEL_PATH\" \"$@\"\n"
+          },
+          {
+            "name": "ocamlfind.install",
+            "content":
+              "bin: [\n  \"src/findlib/ocamlfind\" {\"ocamlfind\"}\n  \"?src/findlib/ocamlfind_opt\" {\"ocamlfind\"}\n  \"?tools/safe_camlp4\"\n]\ntoplevel: [\"src/findlib/topfind\"]\n"
+          },
+          {
+            "name": "_esy/build",
+            "content":
+              "#!/bin/bash\n\nset -euo pipefail\nset -x\n\n#\n# Shim OCAMLLIB so that we can write topfind there\n#\n\nREAL_OCAMLLIB=\"$1\"\n\nmkdir -p $cur__install/lib/ocaml\ncd $cur__install/lib/ocaml\n\nfor filename in `ls -1 $REAL_OCAMLLIB`; do\n  ln -s $REAL_OCAMLLIB/$filename $filename;\ndone\n\n#\n# Build\n#\n\ncd $cur__root\n\nexport OCAMLLIB=\"$cur__install/lib/ocaml\"\n\n./configure \\\n  -bindir $cur__install/bin \\\n  -sitelib $cur__install/lib \\\n  -mandir $cur__install/man \\\n  -config $cur__install/lib/findlib.conf \\\n  -no-custom \\\n  -no-camlp4\n\nmake all\nmake opt\nmake install\n\n(opam-installer --prefix=$cur__install || true)\n"
+          }
+        ],
+        "opam": {
+          "name": "ocamlfind",
+          "version": "1.8.0",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"Thomas Gazagnaire <thomas@gazagnaire.org>\"\nauthors: \"Gerd Stolpmann <gerd@gerd-stolpmann.de>\"\nhomepage: \"http://projects.camlcity.org/projects/findlib.html\"\nbug-reports: \"https://gitlab.camlcity.org/gerd/lib-findlib/issues\"\ndepends: [\n  \"conf-m4\" {build}\n]\navailable: ocaml-version >= \"4.00.0\"\nbuild: [\n  [\n    \"./configure\"\n    \"-bindir\"\n    bin\n    \"-sitelib\"\n    lib\n    \"-mandir\"\n    man\n    \"-config\"\n    \"%{lib}%/findlib.conf\"\n    \"-no-custom\"\n    \"-no-topfind\" {preinstalled}\n  ]\n  [make \"all\"]\n  [make \"opt\"] {ocaml-native}\n]\ninstall: [\n  [make \"install\"]\n  [\"install\" \"-m\" \"0755\" \"ocaml-stub\" \"%{bin}%/ocaml\"] {preinstalled}\n]\nremove: [\n  [\"ocamlfind\" \"remove\" \"bytes\"]\n  [\n    \"./configure\"\n    \"-bindir\"\n    bin\n    \"-sitelib\"\n    lib\n    \"-mandir\"\n    man\n    \"-config\"\n    \"%{lib}%/findlib.conf\"\n    \"-no-topfind\" {preinstalled}\n  ]\n  [make \"uninstall\"]\n  [\"rm\" \"-f\" \"%{bin}%/ocaml\"] {preinstalled}\n]\ndev-repo: \"git+https://gitlab.camlcity.org/gerd/lib-findlib.git\"",
+          "override": {
+            "build": [ [ "bash", "./_esy/build", "#{ocaml.lib / 'ocaml'}" ] ],
+            "exportedEnv": {
+              "OCAMLLIB": {
+                "val": "#{@opam/ocamlfind.install / 'lib' / 'ocaml'}",
+                "scope": "global"
+              },
+              "CAML_LD_LIBRARY_PATH": {
+                "val":
+                  "#{@opam/ocamlfind.install / 'lib' / 'ocaml' / 'stublibs' : @opam/ocamlfind.install / 'lib' / 'ocaml' : $CAML_LD_LIBRARY_PATH}",
+                "scope": "global"
+              },
+              "OCAML_TOPLEVEL_PATH": {
+                "val": "#{@opam/ocamlfind.install / 'lib' / 'ocaml'}",
+                "scope": "global"
+              }
+            }
+          }
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/conf-m4@opam:1"
+      ]
+    },
+    "@opam/ocamlbuild@opam:0.12.0": {
+      "record": {
+        "name": "@opam/ocamlbuild",
+        "version": "opam:0.12.0",
+        "source":
+          "archive:https://github.com/ocaml/ocamlbuild/archive/0.12.0.tar.gz#md5:442baa19470bd49150f153122e22907b",
+        "files": [],
+        "opam": {
+          "name": "ocamlbuild",
+          "version": "0.12.0",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"Gabriel Scherer <gabriel.scherer@gmail.com>\"\nauthors: [\"Nicolas Pouillard\" \"Berke Durak\"]\nlicense: \"LGPL-2 with OCaml linking exception\"\nhomepage: \"https://github.com/ocaml/ocamlbuild/\"\ndoc: \"https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc\"\nbug-reports: \"https://github.com/ocaml/ocamlbuild/issues\"\nconflicts: [\n  \"base-ocamlbuild\"\n  \"ocamlfind\" {< \"1.6.2\"}\n]\navailable: ocaml-version >= \"4.03\"\nbuild: [\n  [\n    make\n    \"-f\"\n    \"configure.make\"\n    \"all\"\n    \"OCAMLBUILD_PREFIX=%{prefix}%\"\n    \"OCAMLBUILD_BINDIR=%{bin}%\"\n    \"OCAMLBUILD_LIBDIR=%{lib}%\"\n    \"OCAMLBUILD_MANDIR=%{man}%\"\n    \"OCAML_NATIVE=%{ocaml-native}%\"\n    \"OCAML_NATIVE_TOOLS=%{ocaml-native}%\"\n  ]\n  [make \"check-if-preinstalled\" \"all\" \"opam-install\"]\n]\ndev-repo: \"git+https://github.com/ocaml/ocamlbuild.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1"
+      ]
+    },
+    "@opam/ocaml-migrate-parsetree@opam:1.0.11": {
+      "record": {
+        "name": "@opam/ocaml-migrate-parsetree",
+        "version": "opam:1.0.11",
+        "source":
+          "archive:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.0.11/ocaml-migrate-parsetree-1.0.11.tbz#md5:26bb1b038de81a79d43ed95c282b2b71",
+        "files": [],
+        "opam": {
+          "name": "ocaml-migrate-parsetree",
+          "version": "1.0.11",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"frederic.bour@lakaban.net\"\nauthors: [\n  \"Frédéric Bour <frederic.bour@lakaban.net>\"\n  \"Jérémie Dimino <jeremie@dimino.org>\"\n]\nlicense: \"LGPL-2.1\"\ntags: [\"syntax\" \"org:ocamllabs\"]\nhomepage: \"https://github.com/ocaml-ppx/ocaml-migrate-parsetree\"\nbug-reports: \"https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues\"\ndepends: [\n  \"result\"\n  \"ocamlfind\" {build}\n  \"jbuilder\" {build & >= \"1.0+beta18.1\"}\n]\navailable: ocaml-version >= \"4.02.0\"\nbuild: [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\ndev-repo: \"git://github.com/ocaml-ppx/ocaml-migrate-parsetree.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/jbuilder@opam:transition", "@opam/ocamlfind@opam:1.8.0",
+        "@opam/result@opam:1.3"
+      ]
+    },
+    "@opam/merlin-extend@opam:0.3": {
+      "record": {
+        "name": "@opam/merlin-extend",
+        "version": "opam:0.3",
+        "source":
+          "archive:https://github.com/let-def/merlin-extend/archive/v0.3.tar.gz#md5:9c6dfd4f53328f02f12fcc265f4e2dda",
+        "files": [],
+        "opam": {
+          "name": "merlin-extend",
+          "version": "0.3",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"Frederic Bour <frederic.bour@lakaban.net>\"\nauthors: \"Frederic Bour <frederic.bour@lakaban.net>\"\nlicense: \"MIT\"\nhomepage: \"https://github.com/let-def/merlin-extend\"\nbug-reports: \"https://github.com/let-def/merlin-extend\"\ndepends: [\n  \"ocamlfind\" {build}\n  \"cppo\" {build}\n]\navailable: ocaml-version >= \"4.02.3\"\nbuild: make\ninstall: [make \"install\"]\nremove: [\"ocamlfind\" \"remove\" \"merlin_extend\"]\ndev-repo: \"git+https://github.com/let-def/merlin-extend.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/cppo@opam:1.6.4", "@opam/ocamlfind@opam:1.8.0"
+      ]
+    },
+    "@opam/menhir@opam:20170509": {
+      "record": {
+        "name": "@opam/menhir",
+        "version": "opam:20170509",
+        "source":
+          "archive:http://gallium.inria.fr/~fpottier/menhir/menhir-20170509.tar.gz#md5:b8ba18b5abda831cf41cd4fa65f4c51b",
+        "files": [],
+        "opam": {
+          "name": "menhir",
+          "version": "20170509",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"francois.pottier@inria.fr\"\nauthors: [\n  \"François Pottier <francois.pottier@inria.fr>\"\n  \"Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>\"\n]\nhomepage: \"http://gallium.inria.fr/~fpottier/menhir/\"\nbug-reports: \"menhir@inria.fr\"\ndepends: [\n  \"ocamlfind\"\n  \"ocamlbuild\" {build}\n]\navailable: ocaml-version >= \"4.02\"\nbuild: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"PREFIX=%{prefix}%\"\n  \"USE_OCAMLFIND=true\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ninstall: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"install\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\nremove: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"uninstall\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ndev-repo: \"git+https://gitlab.inria.fr/fpottier/menhir.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/ocamlbuild@opam:0.12.0", "@opam/ocamlfind@opam:1.8.0"
+      ]
+    },
+    "@opam/jbuilder@opam:transition": {
+      "record": {
+        "name": "@opam/jbuilder",
+        "version": "opam:transition",
+        "source": "no-source:",
+        "files": [],
+        "opam": {
+          "name": "jbuilder",
+          "version": "transition",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"opensource@janestreet.com\"\nauthors: \"Jane Street Group, LLC <opensource@janestreet.com>\"\nlicense: \"MIT\"\nhomepage: \"https://github.com/ocaml/dune\"\nbug-reports: \"https://github.com/ocaml/dune/issues\"\ndepends: [\"dune\"]\npost-messages: [\n  \"Jbuilder has been renamed and the jbuilder package is now a transition\"\n  \"package. Use the dune package instead.\"\n]\ndev-repo: \"git+https://github.com/ocaml/dune.git\"",
+          "override": { "dependencies": { "@opam/ocamlfind": "*" } }
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/dune@opam:1.0.0", "@opam/ocamlfind@opam:1.8.0"
+      ]
+    },
+    "@opam/fmt@opam:0.8.5": {
+      "record": {
+        "name": "@opam/fmt",
+        "version": "opam:0.8.5",
+        "source":
+          "archive:http://erratique.ch/software/fmt/releases/fmt-0.8.5.tbz#md5:77b64aa6f20f09de28f2405d6195f12c",
+        "files": [],
+        "opam": {
+          "name": "fmt",
+          "version": "0.8.5",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"Daniel Bünzli <daniel.buenzl i@erratique.ch>\"\nauthors: [\"Daniel Bünzli <daniel.buenzl i@erratique.ch>\" \"Gabriel Radanne\"]\nlicense: \"ISC\"\ntags: [\"string\" \"format\" \"pretty-print\" \"org:erratique\"]\nhomepage: \"http://erratique.ch/software/fmt\"\ndoc: \"http://erratique.ch/software/fmt\"\nbug-reports: \"https://github.com/dbuenzli/fmt/issues\"\ndepends: [\n  \"ocamlfind\" {build}\n  \"ocamlbuild\" {build}\n  \"topkg\" {build & >= \"0.9.0\"}\n  \"result\"\n  \"uchar\"\n]\ndepopts: [\"base-unix\" \"cmdliner\"]\nconflicts: [\n  \"cmdliner\" {< \"0.9.8\"}\n]\navailable: ocaml-version >= \"4.01.0\"\nbuild: [\n  \"ocaml\"\n  \"pkg/pkg.ml\"\n  \"build\"\n  \"--dev-pkg\"\n  \"%{pinned}%\"\n  \"--with-base-unix\"\n  \"%{base-unix:installed}%\"\n  \"--with-cmdliner\"\n  \"%{cmdliner:installed}%\"\n]\ndev-repo: \"git+http://erratique.ch/repos/fmt.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/ocamlbuild@opam:0.12.0", "@opam/ocamlfind@opam:1.8.0",
+        "@opam/result@opam:1.3", "@opam/topkg@opam:0.9.1",
+        "@opam/uchar@opam:0.0.2"
+      ]
+    },
+    "@opam/easy-format@opam:1.3.1": {
+      "record": {
+        "name": "@opam/easy-format",
+        "version": "opam:1.3.1",
+        "source":
+          "archive:https://github.com/mjambon/easy-format/archive/v1.3.1.tar.gz#md5:4e163700fb88fdcd6b8976c3a216c8ea",
+        "files": [],
+        "opam": {
+          "name": "easy-format",
+          "version": "1.3.1",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"martin@mjambon.com\"\nauthors: \"Martin Jambon\"\nhomepage: \"http://mjambon.com/easy-format.html\"\nbug-reports: \"https://github.com/mjambon/easy-format/issues\"\ndepends: [\n  \"jbuilder\" {build}\n]\navailable: ocaml-version >= \"4.02.3\"\nbuild: [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\nrun-test: [\"jbuilder\" \"runtest\" \"-p\" name]\ndev-repo: \"git+https://github.com/mjambon/easy-format.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/jbuilder@opam:transition"
+      ]
+    },
+    "@opam/dune@opam:1.0.0": {
+      "record": {
+        "name": "@opam/dune",
+        "version": "opam:1.0.0",
+        "source":
+          "archive:https://github.com/ocaml/dune/releases/download/1.0.0/dune-1.0.0.tbz#md5:7435bc09a3967bf6da01e6cb7d37ccc3",
+        "files": [],
+        "opam": {
+          "name": "dune",
+          "version": "1.0.0",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"opensource@janestreet.com\"\nauthors: \"Jane Street Group, LLC <opensource@janestreet.com>\"\nlicense: \"MIT\"\nhomepage: \"https://github.com/ocaml/dune\"\nbug-reports: \"https://github.com/ocaml/dune/issues\"\nconflicts: [\n  \"jbuilder\" {!= \"transition\"}\n]\navailable: ocaml-version >= \"4.02.3\"\nbuild: [\n  [\"ocaml\" \"configure.ml\" \"--libdir\" lib]\n  [\"ocaml\" \"bootstrap.ml\"]\n  [\"./boot.exe\" \"--release\" \"--subst\"] {pinned}\n  [\"./boot.exe\" \"--release\" \"-j\" jobs]\n]\ndev-repo: \"git+https://github.com/ocaml/dune.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1"
+      ]
+    },
+    "@opam/cppo_ocamlbuild@opam:1.6.0": {
+      "record": {
+        "name": "@opam/cppo_ocamlbuild",
+        "version": "opam:1.6.0",
+        "source":
+          "archive:https://github.com/mjambon/cppo/archive/v1.6.0.tar.gz#md5:aee411b3546bc5d198c71ae9185cade4",
+        "files": [],
+        "opam": {
+          "name": "cppo_ocamlbuild",
+          "version": "1.6.0",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"martin@mjambon.com\"\nauthors: \"Martin Jambon\"\nlicense: \"BSD-3-Clause\"\nhomepage: \"http://mjambon.com/cppo.html\"\nbug-reports: \"https://github.com/mjambon/cppo/issues\"\ndepends: [\n  \"jbuilder\" {build & >= \"1.0+beta10\"}\n  \"ocamlbuild\"\n  \"cppo\" {>= \"1.6.0\"}\n]\nbuild: [\n  [\"jbuilder\" \"subst\" \"-p\" name] {pinned}\n  [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\n]\ndev-repo: \"git+https://github.com/mjambon/cppo.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/cppo@opam:1.6.4", "@opam/jbuilder@opam:transition",
+        "@opam/ocamlbuild@opam:0.12.0"
+      ]
+    },
+    "@opam/cppo@opam:1.6.4": {
+      "record": {
+        "name": "@opam/cppo",
+        "version": "opam:1.6.4",
+        "source":
+          "archive:https://github.com/mjambon/cppo/archive/v1.6.4.tar.gz#md5:f7a4a6a0e83b76562b45db3a93ffd204",
+        "files": [],
+        "opam": {
+          "name": "cppo",
+          "version": "1.6.4",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"martin@mjambon.com\"\nauthors: \"Martin Jambon\"\nlicense: \"BSD-3-Clause\"\nhomepage: \"https://github.com/mjambon/cppo\"\nbug-reports: \"https://github.com/mjambon/cppo/issues\"\ndepends: [\n  \"jbuilder\" {build & >= \"1.0+beta17\"}\n  \"base-bytes\"\n  \"base-unix\"\n]\nbuild: [\n  [\"jbuilder\" \"subst\" \"-p\" name] {pinned}\n  [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\n]\nrun-test: [\"jbuilder\" \"runtest\" \"-p\" name]\ndev-repo: \"git+https://github.com/mjambon/cppo.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/base-bytes@opam:base", "@opam/base-unix@opam:base",
+        "@opam/jbuilder@opam:transition"
+      ]
+    },
+    "@opam/conf-which@opam:1": {
+      "record": {
+        "name": "@opam/conf-which",
+        "version": "opam:1",
+        "source": "no-source:",
+        "files": [],
+        "opam": {
+          "name": "conf-which",
+          "version": "1",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"unixjunkie@sdf.org\"\nauthors: \"Carlo Wood\"\nlicense: \"GPL-2+\"\nhomepage: \"http://www.gnu.org/software/which/\"\nbug-reports: \"https://github.com/ocaml/opam-repository/issues\"\nbuild: [\"which\" \"which\"]\ndepexts: [\n  [\"which\"] {\"centos\"}\n  [\"which\"] {\"fedora\"}\n  [\"which\"] {\"opensuse\"}\n  [\"debianutils\"] {\"debian\"}\n  [\"debianutils\"] {\"ubuntu\"}\n  [\"which\"] {\"nixpkgs\"}\n  [\"which\"] {\"archlinux\"}\n]\ndev-repo: \"git+https://github.com/ocaml/opam-repository.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1"
+      ]
+    },
+    "@opam/conf-m4@opam:1": {
+      "record": {
+        "name": "@opam/conf-m4",
+        "version": "opam:1",
+        "source": "no-source:",
+        "files": [],
+        "opam": {
+          "name": "conf-m4",
+          "version": "1",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"tim@gfxmonk.net\"\nlicense: \"GPL-3\"\nhomepage: \"http://www.gnu.org/software/m4/m4.html\"\nbug-reports: \"https://github.com/ocaml/opam-repository/issues\"\nbuild: [\"sh\" \"-exc\" \"echo | m4\"]\ndepexts: [\n  [\"m4\"] {\"debian\"}\n  [\"m4\"] {\"ubuntu\"}\n  [\"m4\"] {\"fedora\"}\n  [\"m4\"] {\"rhel\"}\n  [\"m4\"] {\"centos\"}\n  [\"m4\"] {\"alpine\"}\n  [\"m4\"] {\"nixpkgs\"}\n  [\"m4\"] {\"opensuse\"}\n  [\"m4\"] {\"oraclelinux\"}\n  [\"m4\"] {\"archlinux\"}\n]\ndev-repo: \"git+https://github.com/ocaml/opam-repository.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1"
+      ]
+    },
+    "@opam/cmdliner@opam:1.0.2": {
+      "record": {
+        "name": "@opam/cmdliner",
+        "version": "opam:1.0.2",
+        "source":
+          "archive:http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.2.tbz#md5:ab2f0130e88e8dcd723ac6154c98a881",
+        "files": [],
+        "opam": {
+          "name": "cmdliner",
+          "version": "1.0.2",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"Daniel Bünzli <daniel.buenzl i@erratique.ch>\"\nauthors: \"Daniel Bünzli <daniel.buenzl i@erratique.ch>\"\nlicense: \"ISC\"\ntags: [\"cli\" \"system\" \"declarative\" \"org:erratique\"]\nhomepage: \"http://erratique.ch/software/cmdliner\"\ndoc: \"http://erratique.ch/software/cmdliner/doc/Cmdliner\"\nbug-reports: \"https://github.com/dbuenzli/cmdliner/issues\"\ndepends: [\n  \"ocamlfind\" {build}\n  \"ocamlbuild\" {build}\n  \"topkg\" {build}\n  \"result\"\n]\navailable: ocaml-version >= \"4.01.0\"\nbuild: [\"ocaml\" \"pkg/pkg.ml\" \"build\" \"--pinned\" \"%{pinned}%\"]\ndev-repo: \"git+http://erratique.ch/repos/cmdliner.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/ocamlbuild@opam:0.12.0", "@opam/ocamlfind@opam:1.8.0",
+        "@opam/result@opam:1.3", "@opam/topkg@opam:0.9.1"
+      ]
+    },
+    "@opam/biniou@opam:1.2.0": {
+      "record": {
+        "name": "@opam/biniou",
+        "version": "opam:1.2.0",
+        "source":
+          "archive:https://github.com/mjambon/biniou/archive/v1.2.0.tar.gz#md5:f3e92358e832ed94eaf23ce622ccc2f9",
+        "files": [],
+        "opam": {
+          "name": "biniou",
+          "version": "1.2.0",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"martin@mjambon.com\"\nauthors: \"Martin Jambon\"\nlicense: \"BSD-3-Clause\"\nhomepage: \"https://github.com/mjambon/biniou\"\nbug-reports: \"https://github.com/mjambon/biniou/issues\"\ndepends: [\n  \"conf-which\" {build}\n  \"jbuilder\" {build & >= \"1.0+beta7\"}\n  \"easy-format\"\n]\navailable: ocaml-version >= \"4.02.3\"\nbuild: [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\nrun-test: [\"jbuilder\" \"runtest\" \"-p\" name]\ndev-repo: \"git+https://github.com/mjambon/biniou.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/conf-which@opam:1", "@opam/easy-format@opam:1.3.1",
+        "@opam/jbuilder@opam:transition"
+      ]
+    },
+    "@opam/base-unix@opam:base": {
+      "record": {
+        "name": "@opam/base-unix",
+        "version": "opam:base",
+        "source": "no-source:",
+        "files": [],
+        "opam": {
+          "name": "base-unix",
+          "version": "base",
+          "opam":
+            "opam-version: \"1\"\nmaintainer: \"https://github.com/ocaml/opam-repository/issues\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1"
+      ]
+    },
+    "@opam/base-bytes@opam:base": {
+      "record": {
+        "name": "@opam/base-bytes",
+        "version": "opam:base",
+        "source": "no-source:",
+        "files": [],
+        "opam": {
+          "name": "base-bytes",
+          "version": "base",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \" \"\nauthors: \" \"\nhomepage: \" \"\ndepends: [\n  \"ocamlfind\" {>= \"1.5.3\"}\n]\navailable: ocaml-version >= \"4.02.0\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/ocamlfind@opam:1.8.0"
+      ]
+    },
+    "@opam/astring@opam:0.8.3": {
+      "record": {
+        "name": "@opam/astring",
+        "version": "opam:0.8.3",
+        "source":
+          "archive:http://erratique.ch/software/astring/releases/astring-0.8.3.tbz#md5:c5bf6352b9ac27fbeab342740f4fa870",
+        "files": [],
+        "opam": {
+          "name": "astring",
+          "version": "0.8.3",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"Daniel Bünzli <daniel.buenzl i@erratique.ch>\"\nauthors: \"Daniel Bünzli <daniel.buenzl i@erratique.ch>\"\nlicense: \"ISC\"\ntags: [\"string\" \"org:erratique\"]\nhomepage: \"http://erratique.ch/software/astring\"\ndoc: \"http://erratique.ch/software/astring/doc\"\nbug-reports: \"https://github.com/dbuenzli/astring/issues\"\ndepends: [\n  \"ocamlfind\" {build}\n  \"ocamlbuild\" {build}\n  \"topkg\" {build}\n  \"base-bytes\"\n]\navailable: ocaml-version >= \"4.01.0\"\nbuild: [\"ocaml\" \"pkg/pkg.ml\" \"build\" \"--pinned\" \"%{pinned}%\"]\ndev-repo: \"git+http://erratique.ch/repos/astring.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/base-bytes@opam:base", "@opam/ocamlbuild@opam:0.12.0",
+        "@opam/ocamlfind@opam:1.8.0", "@opam/topkg@opam:0.9.1"
+      ]
+    },
+    "@opam/alcotest@opam:0.8.3": {
+      "record": {
+        "name": "@opam/alcotest",
+        "version": "opam:0.8.3",
+        "source":
+          "archive:https://github.com/mirage/alcotest/releases/download/0.8.3/alcotest-0.8.3.tbz#md5:597e6bb271bd42062f95aa67afdb9185",
+        "files": [],
+        "opam": {
+          "name": "alcotest",
+          "version": "0.8.3",
+          "opam":
+            "opam-version: \"1.2\"\nmaintainer: \"thomas@gazagnaire.org\"\nauthors: \"Thomas Gazagnaire\"\nlicense: \"ISC\"\nhomepage: \"https://github.com/mirage/alcotest/\"\ndoc: \"https://mirage.github.io/alcotest/\"\nbug-reports: \"https://github.com/mirage/alcotest/issues/\"\ndepends: [\n  \"jbuilder\" {build & >= \"1.0+beta10\"}\n  \"fmt\" {>= \"0.8.0\"}\n  \"astring\"\n  \"result\"\n  \"cmdliner\"\n]\navailable: ocaml-version >= \"4.02.3\"\nbuild: [\n  [\"jbuilder\" \"subst\" \"-p\" name] {pinned}\n  [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\n]\nrun-test: [\"jbuilder\" \"runtest\" \"-p\" name \"-j\" jobs]\ndev-repo: \"git+https://github.com/mirage/alcotest.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/astring@opam:0.8.3", "@opam/cmdliner@opam:1.0.2",
+        "@opam/fmt@opam:0.8.5", "@opam/jbuilder@opam:transition",
+        "@opam/result@opam:1.3"
+      ]
+    },
+    "@esy-ocaml/substs@0.0.1": {
+      "record": {
+        "name": "@esy-ocaml/substs",
+        "version": "0.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/@esy-ocaml/substs/-/substs-0.0.1.tgz#sha1:59ebdbbaedcda123fc7ed8fb2b302b7d819e9a46",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "@esy-ocaml/reason@3.3.0": {
+      "record": {
+        "name": "@esy-ocaml/reason",
+        "version": "3.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/@esy-ocaml/reason/-/reason-3.3.0.tgz#sha1:8d282f5cc5c569b8b5ca5ef4203050d070febd5b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/jbuilder@opam:transition", "@opam/menhir@opam:20170509",
+        "@opam/merlin-extend@opam:0.3",
+        "@opam/ocaml-migrate-parsetree@opam:1.0.11",
+        "@opam/ocamlfind@opam:1.8.0", "@opam/result@opam:1.3"
+      ]
+    },
+    "@esy-ocaml/merlin@3.0.5005": {
+      "record": {
+        "name": "@esy-ocaml/merlin",
+        "version": "3.0.5005",
+        "source":
+          "archive:https://registry.npmjs.org/@esy-ocaml/merlin/-/merlin-3.0.5005.tgz#sha1:4a9e2b4df20672524603b7b1797b7761d5d0d9ad",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
+        "@opam/ocamlfind@opam:1.8.0", "@opam/yojson@opam:1.4.1"
+      ]
+    },
+    "@esy-ocaml/esy-installer@0.0.0": {
+      "record": {
+        "name": "@esy-ocaml/esy-installer",
+        "version": "0.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/@esy-ocaml/esy-installer/-/esy-installer-0.0.0.tgz#sha1:6b0e2bd4ee43531ac74793fe55cfcc3aca197a66",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    }
+  }
+}


### PR DESCRIPTION
This is a first step towards bringing in platform-specific renderers.

MountLog will go through rendered element and prepare an actionable list(?) of changes, based on which host renderers will manipulate UI: add subview, remove subview, etc.

- [x] `MountLog.fromRenderedElement` - given `renderedElement` instance, prepare a list of MountLog entries (most of them would probably be just `MountChild` - abstract name for `addSubview`).
- [x] `MountLog.fromTopLevelUpdate`, `MountLog.fromUpdateLog` - same thing, but for an updated elements tree. This brings `UnmountChild` and probably some sort of priority.
- [x] Implement mount log application for `topLevelUpdate`'s `subtreeChange`
- [x] Outline all kinds of mount log entries we need and could abstract into core.
