### PR TITLE
Replace old ReasonReact-like API with Hooks

### DIFF
--- a/core/lib/Hooks.re
+++ b/core/lib/Hooks.re
@@ -26,3 +26,10 @@ let useRef = (initialState, slots) => {
 
   (state^, setter, nextSlots);
 };
+
+let flushPendingUpdates = slots =>
+  Slots.fold(
+    (_, shouldUpdate, ~flush) => flush() || shouldUpdate,
+    false,
+    slots,
+  );

--- a/core/lib/Hooks.re
+++ b/core/lib/Hooks.re
@@ -1,45 +1,28 @@
-let useReducer:
-  type state action.
-    (
-      ~initialState: state,
-      (action, state) => state,
-      Slots.t(state, Slots.t('slot, 'nextSlots))
-    ) =>
-    (state, action => unit, Slots.t('slot, 'nextSlots)) =
-  (~initialState, reducer, slots) => {
-    let ((state, setState), nextSlots) =
-      Slots.use(~default=initialState, slots);
+let useReducer = (~initialState, reducer, slots) => {
+  let ((state, setState), nextSlots) =
+    Slots.use(~default=initialState, slots);
 
-    let dispatch = (action: action) =>
-      setState(prevValue => reducer(action, prevValue));
+  let dispatch = action => setState(prevValue => reducer(action, prevValue));
 
-    (state, dispatch, nextSlots);
-  };
+  (state, dispatch, nextSlots);
+};
 
-let useState:
-  type state.
-    (state, Slots.t(state, Slots.t('slot, 'nextSlots))) =>
-    (state, state => unit, Slots.t('slot, 'nextSlots)) =
-  (initialState, slots) => {
-    let ((state, setState), nextSlots) =
-      Slots.use(~default=initialState, slots);
+let useState = (initialState, slots) => {
+  let ((state, setState), nextSlots) =
+    Slots.use(~default=initialState, slots);
 
-    let setter = (nextState: state) => setState(_ => nextState);
+  let setter = nextState => setState(_ => nextState);
 
-    (state, setter, nextSlots);
-  };
+  (state, setter, nextSlots);
+};
 
-let useRef:
-  type state.
-    (state, Slots.t(ref(state), Slots.t('slot, 'nextSlots))) =>
-    (state, state => unit, Slots.t('slot, 'nextSlots)) =
-  (initialState, slots) => {
-    let ((state, _), nextSlots) =
-      Slots.use(~default=ref(initialState), slots);
+let useRef = (initialState, slots) => {
+  let ((state, _), nextSlots) =
+    Slots.use(~default=ref(initialState), slots);
 
-    let setter = nextValue =>
-      /* do this after all updates are commited to the OutputTree */
-      state := nextValue;
+  let setter = nextValue =>
+    /* do this after all updates are commited to the OutputTree */
+    state := nextValue;
 
-    (state^, setter, nextSlots);
-  };
+  (state^, setter, nextSlots);
+};

--- a/core/lib/Hooks.re
+++ b/core/lib/Hooks.re
@@ -1,0 +1,45 @@
+let useReducer:
+  type state action.
+    (
+      ~initialState: state,
+      (action, state) => state,
+      Slots.t(state, Slots.t('slot, 'nextSlots))
+    ) =>
+    (state, action => unit, Slots.t('slot, 'nextSlots)) =
+  (~initialState, reducer, slots) => {
+    let ((state, setState), nextSlots) =
+      Slots.use(~default=initialState, slots);
+
+    let dispatch = (action: action) =>
+      setState(prevValue => reducer(action, prevValue));
+
+    (state, dispatch, nextSlots);
+  };
+
+let useState:
+  type state.
+    (state, Slots.t(state, Slots.t('slot, 'nextSlots))) =>
+    (state, state => unit, Slots.t('slot, 'nextSlots)) =
+  (initialState, slots) => {
+    let ((state, setState), nextSlots) =
+      Slots.use(~default=initialState, slots);
+
+    let setter = (nextState: state) => setState(_ => nextState);
+
+    (state, setter, nextSlots);
+  };
+
+let useRef:
+  type state.
+    (state, Slots.t(ref(state), Slots.t('slot, 'nextSlots))) =>
+    (state, state => unit, Slots.t('slot, 'nextSlots)) =
+  (initialState, slots) => {
+    let ((state, _), nextSlots) =
+      Slots.use(~default=ref(initialState), slots);
+
+    let setter = nextValue =>
+      /* do this after all updates are commited to the OutputTree */
+      state := nextValue;
+
+    (state^, setter, nextSlots);
+  };

--- a/core/lib/Hooks.re
+++ b/core/lib/Hooks.re
@@ -1,35 +1,248 @@
-let useReducer = (~initialState, reducer, slots) => {
-  let ((state, setState), nextSlots) =
-    Slots.use(~default=initialState, slots);
+type hook('a) = ..;
 
-  let dispatch = action => setState(prevValue => reducer(action, prevValue));
+module Slots =
+  Slots.Make({
+    type t('a) = hook('a);
+  });
 
-  (state, dispatch, nextSlots);
+type t('a, 'b) = Slots.t('a, 'b);
+type empty = Slots.empty;
+
+let create = Slots.create;
+
+module State = {
+  type stateContainer('a) = {
+    currentValue: 'a,
+    nextValue: 'a,
+  };
+
+  type t('a) = ref(stateContainer('a));
+
+  type hook('a) +=
+    | State(t('a)): hook(t('a));
+
+  let make: 'a => t('a) =
+    initialValue =>
+      ref({currentValue: initialValue, nextValue: initialValue});
+
+  let flush: t('a) => bool =
+    stateContainer => {
+      let {currentValue, nextValue} = stateContainer^;
+      if (currentValue !== nextValue) {
+        stateContainer := {currentValue: nextValue, nextValue};
+        true;
+      } else {
+        false;
+      };
+    };
+
+  let wrapAsHook = s => State(s);
+
+  let setState = (nextValue, stateContainer) =>
+    stateContainer := {currentValue: stateContainer^.currentValue, nextValue};
+
+  let hook = (initialState, slots) => {
+    let (stateContainer, nextSlots) =
+      Slots.use(
+        ~default=() => make(initialState),
+        ~toElem=wrapAsHook,
+        slots,
+      );
+
+    let setter = nextState => setState(nextState, stateContainer);
+
+    (stateContainer^.currentValue, setter, nextSlots);
+  };
 };
 
-let useState = (initialState, slots) => {
-  let ((state, setState), nextSlots) =
-    Slots.use(~default=initialState, slots);
+module Reducer = {
+  type reducerState('a) = {
+    currentValue: 'a,
+    updates: list('a => 'a),
+  };
 
-  let setter = nextState => setState(_ => nextState);
+  type t('a) = ref(reducerState('a));
 
-  (state, setter, nextSlots);
+  type hook('a) +=
+    | Reducer(t('a)): hook(t('a));
+
+  let make: 'a => t('a) =
+    initialValue => ref({currentValue: initialValue, updates: []});
+
+  let flush: t('a) => bool =
+    reducerState => {
+      let {currentValue, updates} = reducerState^;
+      let nextValue =
+        List.fold_right(
+          (update, latestValue) => update(latestValue),
+          updates,
+          currentValue,
+        );
+
+      reducerState := {currentValue: nextValue, updates: []};
+      currentValue !== nextValue;
+    };
+
+  let wrapAsHook = s => Reducer(s);
+
+  let enqueueUpdate = (nextUpdate, stateContainer) => {
+    let {currentValue, updates} = stateContainer^;
+
+    stateContainer := {currentValue, updates: [nextUpdate, ...updates]};
+  };
+
+  let hook = (~initialState, reducer, slots) => {
+    let (stateContainer, nextSlots) =
+      Slots.use(
+        ~default=() => make(initialState),
+        ~toElem=wrapAsHook,
+        slots,
+      );
+
+    let dispatch = action =>
+      enqueueUpdate(prevValue => reducer(action, prevValue), stateContainer);
+
+    (stateContainer^.currentValue, dispatch, nextSlots);
+  };
 };
 
-let useRef = (initialState, slots) => {
-  let ((state, _), nextSlots) =
-    Slots.use(~default=ref(initialState), slots);
+module Ref = {
+  type t('a) = ref('a);
+  type hook('a) +=
+    | Ref(t('a)): hook(t('a));
+  let wrapAsHook = s => Ref(s);
 
-  let setter = nextValue =>
-    /* do this after all updates are commited to the OutputTree */
-    state := nextValue;
+  let hook = (initialState, slots) => {
+    let (internalRef, nextSlots) =
+      Slots.use(~default=() => ref(initialState), ~toElem=wrapAsHook, slots);
 
-  (state^, setter, nextSlots);
+    let setter = nextValue => internalRef := nextValue;
+
+    (internalRef^, setter, nextSlots);
+  };
 };
 
-let flushPendingUpdates = slots =>
+module Effect = {
+  type lifecycle =
+    | Mount
+    | Unmount
+    | Update;
+  type always;
+  type onMount;
+  type condition('a) =
+    | Always: condition(always)
+    | OnMount: condition(onMount)
+    | If(('a, 'a) => bool, 'a): condition('a);
+  type handler = unit => option(unit => unit);
+  type t('a) = {
+    mutable condition: condition('a),
+    mutable handler: unit => option(unit => unit),
+    mutable cleanupHandler: option(unit => unit),
+    mutable previousCondition: condition('a),
+  };
+  type hook('a) +=
+    | Effect(t('a)): hook(t('a));
+
+  let wrapAsHook = s => Effect(s);
+
+  let executeOptionalHandler =
+    fun
+    | Some(f) => {
+        f();
+        true;
+      }
+    | None => false;
+
+  let executeIfNeeded:
+    type conditionValue. (~lifecycle: lifecycle, t(conditionValue)) => bool =
+    (~lifecycle, state) => {
+      let {condition, previousCondition, handler, cleanupHandler} = state;
+      switch (previousCondition) {
+      | Always =>
+        ignore(executeOptionalHandler(cleanupHandler));
+        state.cleanupHandler = handler();
+        true;
+      | If(comparator, previousConditionValue) =>
+        switch (lifecycle) {
+        | Mount
+        | Update =>
+          let currentConditionValue =
+            switch (condition) {
+            | If(_, currentConditionValue) => currentConditionValue
+            /* The following cases are unreachable because it's
+             * Impossible to create a value of type condition(always)
+             * Or condition(onMount) using the If constructor
+             */
+            | Always => previousConditionValue
+            | OnMount => previousConditionValue
+            };
+          if (comparator(previousConditionValue, currentConditionValue)) {
+            ignore(executeOptionalHandler(cleanupHandler));
+            state.previousCondition = condition;
+            state.cleanupHandler = handler();
+            true;
+          } else {
+            state.previousCondition = condition;
+            false;
+          };
+        | Unmount => executeOptionalHandler(cleanupHandler)
+        }
+      | OnMount =>
+        switch (lifecycle) {
+        | Mount =>
+          state.cleanupHandler = handler();
+          true;
+        | Unmount => executeOptionalHandler(cleanupHandler)
+        | _ => false
+        }
+      };
+    };
+
+  let hook = (condition, handler, slots) => {
+    let (state, nextSlots) =
+      Slots.use(
+        ~default=
+          () => {
+            condition,
+            handler,
+            cleanupHandler: None,
+            previousCondition: condition,
+          },
+        ~toElem=wrapAsHook,
+        slots,
+      );
+
+    state.condition = condition;
+    state.handler = handler;
+    nextSlots;
+  };
+};
+
+let state = State.hook;
+let reducer = Reducer.hook;
+let ref = Ref.hook;
+let effect = Effect.hook;
+
+let executeEffects = (~lifecycle, slots) =>
   Slots.fold(
-    (_, shouldUpdate, ~flush) => flush() || shouldUpdate,
+    (Any(hook), shouldUpdate) =>
+      switch (hook) {
+      | Effect.Effect(state) =>
+        Effect.executeIfNeeded(~lifecycle, state) || shouldUpdate
+      | _ => shouldUpdate
+      },
+    false,
+    slots,
+  );
+
+let flushPendingStateUpdates = slots =>
+  Slots.fold(
+    (Any(hook), shouldUpdate) =>
+      switch (hook) {
+      | State.State(state) => State.flush(state) || shouldUpdate
+      | Reducer.Reducer(state) => Reducer.flush(state) || shouldUpdate
+      | _ => shouldUpdate
+      },
     false,
     slots,
   );

--- a/core/lib/Hooks.re
+++ b/core/lib/Hooks.re
@@ -53,7 +53,7 @@ module State = {
     let (stateContainer, nextSlots) =
       Slots.use(
         ~default=() => make(initialState),
-        ~toElem=wrapAsHook,
+        ~toWitness=wrapAsHook,
         hooks.slots,
       );
 
@@ -103,7 +103,7 @@ module Reducer = {
     let (stateContainer, nextSlots) =
       Slots.use(
         ~default=() => make(initialState),
-        ~toElem=wrapAsHook,
+        ~toWitness=wrapAsHook,
         hooks.slots,
       );
 
@@ -126,7 +126,7 @@ module Ref = {
     let (internalRef, nextSlots) =
       Slots.use(
         ~default=() => ref(initialState),
-        ~toElem=wrapAsHook,
+        ~toWitness=wrapAsHook,
         hooks.slots,
       );
 
@@ -222,7 +222,7 @@ module Effect = {
             cleanupHandler: None,
             previousCondition: condition,
           },
-        ~toElem=wrapAsHook,
+        ~toWitness=wrapAsHook,
         hooks.slots,
       );
 

--- a/core/lib/Hooks.rei
+++ b/core/lib/Hooks.rei
@@ -1,0 +1,74 @@
+type hook('a) = ..;
+
+module Slots: Slots.S with type elem('a) = hook('a);
+
+type t('a, 'b) = Slots.t('a, 'b);
+type empty = Slots.empty;
+
+let create: unit => t('a, 'b);
+
+module State: {
+  type t('a);
+  type hook('a) +=
+    pri
+    | State(t('a)): hook(t('a));
+};
+
+module Reducer: {
+  type t('a);
+  type hook('a) +=
+    pri
+    | Reducer(t('a)): hook(t('a));
+};
+
+module Ref: {
+  type t('a);
+  type hook('a) +=
+    pri
+    | Ref(t('a)): hook(t('a));
+};
+
+module Effect: {
+  type t('a);
+  type lifecycle =
+    | Mount
+    | Unmount
+    | Update;
+  type always;
+  type onMount;
+  type condition('a) =
+    | Always: condition(always)
+    | OnMount: condition(onMount)
+    | If(('a, 'a) => bool, 'a): condition('a);
+  type handler = unit => option(unit => unit);
+  type hook('a) +=
+    pri
+    | Effect(t('a)): hook(t('a));
+};
+
+let state:
+  ('state, t(State.t('state), t('slots, 'nextSlots))) =>
+  ('state, 'state => unit, t('slots, 'nextSlots));
+
+let reducer:
+  (
+    ~initialState: 'state,
+    ('action, 'state) => 'state,
+    t(Reducer.t('state), t('slots, 'nextSlots))
+  ) =>
+  ('state, 'action => unit, t('slots, 'nextSlots));
+
+let ref:
+  ('state, t(Ref.t('state), t('slots, 'nextSlots))) =>
+  ('state, 'state => unit, t('slots, 'nextSlots));
+
+let effect:
+  (
+    Effect.condition('condition),
+    Effect.handler,
+    t(Effect.t('condition), t('slots, 'nextSlots))
+  ) =>
+  t('slots, 'nextSlots);
+
+let executeEffects: (~lifecycle: Effect.lifecycle, t('a, 'b)) => bool;
+let flushPendingStateUpdates: t('a, 'b) => bool;

--- a/core/lib/Hooks.rei
+++ b/core/lib/Hooks.rei
@@ -2,10 +2,13 @@ type hook('a) = ..;
 
 module Slots: Slots.S with type elem('a) = hook('a);
 
-type t('a, 'b) = Slots.t('a, 'b);
-type empty = Slots.empty;
+type t('a, 'b) = {
+  slots: Slots.t('a, 'b),
+  onSlotsDidChange: unit => unit,
+};
+type empty = t(unit, unit);
 
-let create: unit => t('a, 'b);
+let create: (~onSlotsDidChange: unit => unit) => t('a, 'b);
 
 module State: {
   type t('a);
@@ -47,26 +50,26 @@ module Effect: {
 };
 
 let state:
-  ('state, t(State.t('state), t('slots, 'nextSlots))) =>
+  ('state, t(State.t('state), Slots.t('slots, 'nextSlots))) =>
   ('state, 'state => unit, t('slots, 'nextSlots));
 
 let reducer:
   (
     ~initialState: 'state,
     ('action, 'state) => 'state,
-    t(Reducer.t('state), t('slots, 'nextSlots))
+    t(Reducer.t('state), Slots.t('slots, 'nextSlots))
   ) =>
   ('state, 'action => unit, t('slots, 'nextSlots));
 
 let ref:
-  ('state, t(Ref.t('state), t('slots, 'nextSlots))) =>
+  ('state, t(Ref.t('state), Slots.t('slots, 'nextSlots))) =>
   ('state, 'state => unit, t('slots, 'nextSlots));
 
 let effect:
   (
     Effect.condition('condition),
     Effect.handler,
-    t(Effect.t('condition), t('slots, 'nextSlots))
+    t(Effect.t('condition), Slots.t('slots, 'nextSlots))
   ) =>
   t('slots, 'nextSlots);
 

--- a/core/lib/Hooks.rei
+++ b/core/lib/Hooks.rei
@@ -1,6 +1,6 @@
 type hook('a) = ..;
 
-module Slots: Slots.S with type elem('a) = hook('a);
+module Slots: Slots.S with type witness('a) = hook('a);
 
 type t('a, 'b) = {
   slots: Slots.t('a, 'b),

--- a/core/lib/ListTR.re
+++ b/core/lib/ListTR.re
@@ -1,0 +1,36 @@
+let useTailRecursion = l =>
+  switch (l) {
+  | [_, _, _, _, _, _, _, _, _, _, ..._] => true
+  | _ => false
+  };
+let concat = list => {
+  let rec aux = (acc, l) =>
+    switch (l) {
+    | [] => List.rev(acc)
+    | [x, ...rest] => aux(List.rev_append(x, acc), rest)
+    };
+  useTailRecursion(list) ? aux([], list) : List.concat(list);
+};
+let map = (f, list) =>
+  useTailRecursion(list) ?
+    List.rev_map(f, List.rev(list)) : List.map(f, list);
+let map3 = (f, list1, list2, list3) => {
+  let rec aux = acc =>
+    fun
+    | ([], [], []) => acc
+    | ([x1, ...nextList1], [x2, ...nextList2], [x3, ...nextList3]) =>
+      aux([f((x1, x2, x3)), ...acc], (nextList1, nextList2, nextList3))
+    | _ => assert(false);
+  aux([], (List.rev(list1), List.rev(list2), List.rev(list3)));
+};
+let fold3 = (f, list1, list2, list3, initialValue) => {
+  let rec aux = acc =>
+    fun
+    | ([], [], []) => acc
+    | ([x1, ...nextList1], [x2, ...nextList2], [x3, ...nextList3]) => {
+        let nextRes = f(acc, x1, x2, x3);
+        aux(nextRes, (nextList1, nextList2, nextList3));
+      }
+    | _ => assert(false);
+  aux(initialValue, (list1, list2, list3));
+};

--- a/core/lib/ReactCore.rei
+++ b/core/lib/ReactCore.rei
@@ -83,7 +83,7 @@ module Make:
       (
         ~useDynamicKey: bool=?,
         string,
-        Slots.t('slots, 'nextSlots) => syntheticElement
+        Hooks.t('slots, 'nextSlots) => syntheticElement
       ) =>
       component('slots, 'nextSlots, syntheticElement, outputNodeGroup);
 
@@ -91,7 +91,7 @@ module Make:
       (
         ~useDynamicKey: bool=?,
         string,
-        Slots.t('slots, 'nextSlots) => outputTreeElement('slots, 'nextSlots)
+        Hooks.t('slots, 'nextSlots) => outputTreeElement('slots, 'nextSlots)
       ) =>
       component(
         'slots,

--- a/core/lib/ReactCore.rei
+++ b/core/lib/ReactCore.rei
@@ -77,6 +77,8 @@ module Make:
       let flushPendingUpdates: t => t;
 
       let executeHostViewUpdates: t => OutputTree.node;
+
+      let executePendingEffects: t => t;
     };
 
     let component:

--- a/core/lib/ReactCore.rei
+++ b/core/lib/ReactCore.rei
@@ -30,129 +30,31 @@ module Make:
       let create: unit => t;
     };
 
-    module Callback: {
-      /**
-       * Type for callbacks
-       *
-       * This type can be left abstract to prevent calling the callback directly.
-       * For example, calling `update handler event` would force an immediate
-       * call of `handler` with the current state, and can be prevented by defining:
-       *
-       *   type t 'payload;
-       *
-       * However, we do want to support immediate calling of a handler, as an
-       * escape hatch for the existing async setState reactJS pattern
-       */
-      type t('payload) = 'payload => unit;
-
-      /** Default no-op callback */
-      let default: t('payload);
-
-      /** Chain two callbacks by executing the first before the second one */
-      let chain: (t('payload), t('payload)) => t('payload);
-    };
-
-    type reduce('payload, 'action) =
-      ('payload => 'action) => Callback.t('payload);
-
-    type self('state, 'action) = {
-      state: 'state,
-      reduce: 'payload. reduce('payload, 'action),
-      act: 'action => unit,
-    };
-
     /** Type of element returned from render */
     type syntheticElement;
 
     /** Type of element that renders an output node */
-    type outputTreeElement('state, 'action) = {
+    type outputTreeElement('slots, 'nextSlots) = {
       make: unit => OutputTree.node,
-      updateInstance:
-        (self('state, 'action), OutputTree.node) => OutputTree.node,
-      shouldReconfigureInstance:
-        (~oldState: 'state, ~newState: 'state) => bool,
+      configureInstance:
+        (~isFirstRender: bool, OutputTree.node) => OutputTree.node,
       children: syntheticElement,
     };
 
     type elementType('concreteElementType, 'outputNodeType, 'state, 'action);
 
-    type oldNewSelf('state, 'action) = {
-      oldSelf: self('state, 'action),
-      newSelf: self('state, 'action),
-    };
-
-    type update('state, 'action) =
-      | NoUpdate
-      | Update('state);
-
-    type handedOffInstance('state, 'action, 'elementType, 'outputNodeType);
-
-    type componentSpec(
-      'state,
-      'initialState,
-      'action,
-      'elementType,
-      'outputNode,
-    ) = {
-      debugName: string,
-      elementType: elementType('elementType, 'outputNode, 'state, 'action),
-      willReceiveProps: self('state, 'action) => 'state,
-      didMount: self('state, 'action) => unit,
-      didUpdate: oldNewSelf('state, 'action) => unit,
-      willUnmount: self('state, 'action) => unit /* TODO: currently unused */,
-      shouldUpdate: oldNewSelf('state, 'action) => bool,
-      render: self('state, 'action) => 'elementType,
-      initialState: unit => 'initialState,
-      reducer: ('action, 'state) => update('state, 'action),
-      printState: 'state => string /* for internal debugging */,
-      handedOffInstance:
-        handedOffInstance('state, 'action, 'elementType, 'outputNode),
-      key: Key.t,
-    };
-    type component('state, 'action, 'elementType, 'outputNodeType) =
-      componentSpec('state, 'state, 'action, 'elementType, 'outputNodeType);
-
-    type stateless = unit;
-    type actionless = unit;
     type outputNodeGroup;
     type outputNodeContainer;
 
-    type syntheticComponentSpec('state, 'action) =
-      componentSpec(
-        'state,
-        stateless,
-        'action,
-        syntheticElement,
-        outputNodeGroup,
-      );
+    type component('slots, 'nextSlots, 'elementType, 'outputNodeType);
 
-    type outputTreeComponentSpec('state, 'action) =
-      componentSpec(
-        'state,
-        stateless,
-        'action,
-        outputTreeElement('state, 'action),
-        outputNodeContainer,
-      );
-
-    let statelessComponent:
-      (~useDynamicKey: bool=?, string) =>
-      syntheticComponentSpec(stateless, actionless);
-    let statefulComponent:
-      (~useDynamicKey: bool=?, string) =>
-      syntheticComponentSpec('state, actionless);
-    let reducerComponent:
-      (~useDynamicKey: bool=?, string) =>
-      syntheticComponentSpec('state, 'action);
-    let statelessNativeComponent:
-      (~useDynamicKey: bool=?, string) =>
-      outputTreeComponentSpec(stateless, actionless);
     let element:
       (
         ~key: Key.t=?,
-        component('state, 'action, 'elementType, 'hostOutputNode)
+        component('slots, 'nextSlots, 'elementType, 'hostOutputNode)
       ) =>
       syntheticElement;
+
     let listToElement: list(syntheticElement) => syntheticElement;
 
     module RenderedElement: {
@@ -177,23 +79,28 @@ module Make:
       let executeHostViewUpdates: t => OutputTree.node;
     };
 
-    /**
-     * RemoteAction provides a way to send actions to a remote component.
-     * The sender creates a fresh RemoteAction and passes it down.
-     * The recepient component calls subscribe in the didMount method.
-     * The caller can then send actions to the recipient components via act.
-     */
-    module RemoteAction: {
-      type t('action);
+    let component:
+      (
+        ~useDynamicKey: bool=?,
+        string,
+        Slots.t('slots, 'nextSlots) => syntheticElement
+      ) =>
+      component('slots, 'nextSlots, syntheticElement, outputNodeGroup);
 
-      /** Create a new remote action, to which one component will subscribe. */
-      let create: unit => t('action);
+    let nativeComponent:
+      (
+        ~useDynamicKey: bool=?,
+        string,
+        Slots.t('slots, 'nextSlots) => outputTreeElement('slots, 'nextSlots)
+      ) =>
+      component(
+        'slots,
+        'nextSlots,
+        outputTreeElement('slots, 'nextSlots),
+        outputNodeContainer,
+      );
 
-      /** Subscribe to the remote action, via the component's `act` function. */
-      let subscribe: (~act: 'action => unit, t('action)) => unit;
-
-      /** Perform an action on the subscribed component. */
-
-      let act: (t('action), ~action: 'action) => unit;
-    };
+    module Slots = Slots;
+    module Hooks = Hooks;
+    module RemoteAction = RemoteAction;
   };

--- a/core/lib/ReactCore_Internal.re
+++ b/core/lib/ReactCore_Internal.re
@@ -1400,6 +1400,11 @@ module Make = (OutputTree: OutputTree) => {
       OutputTree.commitChanges();
       hostView;
     };
+
+    let executePendingEffects = ({enqueuedEffects} as renderedElement: t) => {
+      List.iter(f => f(), enqueuedEffects);
+      {...renderedElement, enqueuedEffects: []};
+    };
   };
 
   let element = (~key as argumentKey=Key.none, component) => {

--- a/core/lib/ReactCore_Internal.re
+++ b/core/lib/ReactCore_Internal.re
@@ -488,7 +488,7 @@ module Make = (OutputTree: OutputTree) => {
     let rec ofElement =
             (Element(component) as element)
             : (opaqueInstance, list(unit => unit)) => {
-      let slots = Hooks.create();
+      let slots = Hooks.create(~onSlotsDidChange=OutputTree.markAsStale);
       let subElements = component.render(slots);
       let (instanceSubForest, mountEffects) =
         (

--- a/core/lib/ReactCore_Internal.re
+++ b/core/lib/ReactCore_Internal.re
@@ -48,7 +48,7 @@ module Make = (OutputTree: OutputTree) => {
   type outputNodeContainer = Lazy.t(internalOutputNode);
   type outputNodeGroup = list(outputNodeContainer);
   type instance('slots, 'nextSlots, 'elementType, 'outputNode) = {
-    slots: Slots.t('slots, 'nextSlots),
+    slots: Hooks.t('slots, 'nextSlots),
     component: component('slots, 'nextSlots, 'elementType, 'outputNode),
     element,
     instanceSubForest: instanceForest,
@@ -88,7 +88,7 @@ module Make = (OutputTree: OutputTree) => {
     elementType: elementType('slots, 'nextSlots, 'elementType, 'outputNode),
     handedOffInstance:
       ref(option(instance('slots, 'nextSlots, 'elementType, 'outputNode))),
-    render: Slots.t('slots, 'nextSlots) => 'elementType,
+    render: Hooks.t('slots, 'nextSlots) => 'elementType,
   }
   and opaqueInstance =
     | Instance(instance('slots, 'nextSlots, 'elementType, 'outputNode))
@@ -448,7 +448,7 @@ module Make = (OutputTree: OutputTree) => {
 
   module Instance = {
     let rec ofElement = (Element(component) as element): opaqueInstance => {
-      let slots = Slots.create();
+      let slots = Hooks.create();
       let subElements = component.render(slots);
       let instanceSubForest =
         (
@@ -483,7 +483,7 @@ module Make = (OutputTree: OutputTree) => {
       'state 'action 'elementType 'outputNode.
       instance('state, 'action, 'elementType, 'outputNode) => bool
      =
-      instance => Hooks.flushPendingUpdates(instance.slots);
+      instance => Hooks.flushPendingStateUpdates(instance.slots);
 
     type childElementUpdate = {
       updatedRenderedElement: renderedElement,
@@ -1135,7 +1135,8 @@ module Make = (OutputTree: OutputTree) => {
              0,
            ),
       );
-    let render = (nearestHostOutputNode: OutputTree.node, syntheticElement): t => {
+    let render =
+        (nearestHostOutputNode: OutputTree.node, syntheticElement): t => {
       let instanceForest = Instance.ofList(syntheticElement);
       {
         instanceForest,
@@ -1149,7 +1150,9 @@ module Make = (OutputTree: OutputTree) => {
                      {
                        let Node(child) | UpdatedNode(_, child) =
                          Lazy.force(child);
-                       OutputTree.insertNode(~parent, ~child, ~position);
+                       let parent =
+                         OutputTree.insertNode(~parent, ~child, ~position);
+                       parent;
                      },
                    ),
                    (0, nearestHostOutputNode),

--- a/core/lib/ReactCore_Internal.re
+++ b/core/lib/ReactCore_Internal.re
@@ -19,8 +19,7 @@ module Make = (OutputTree: OutputTree) => {
     let reset = () => {
       debug := true;
       componentKeyCounter := 0;
-      /* FIXME: To be done afterwards because we'll need to  adjust tests*/
-      instanceIdCounter := 1;
+      instanceIdCounter := 0;
     };
 
     /**
@@ -1089,10 +1088,6 @@ module Make = (OutputTree: OutputTree) => {
      * Execute the pending updates at the top level of an instance tree.
      * If no state change is performed, the argument is returned unchanged.
      */
-    /**
-     * Flush the pending updates in an instance tree.
-     * TODO: invoke lifecycles
-     */
     let flushPendingUpdates = (opaqueInstance, nearestHostOutputNode) => {
       let Instance({element}) = opaqueInstance;
       updateOpaqueInstance(
@@ -1171,7 +1166,6 @@ module Make = (OutputTree: OutputTree) => {
 
     /**
      * Flush the pending updates in an instance tree.
-     * TODO: invoke lifecycles
      */
     let flushPendingUpdates = ({instanceForest, nearestHostOutputNode}: t): t => {
       let (nearestHostOutputNode, newInstanceForest) =

--- a/core/lib/ReactCore_Internal.re
+++ b/core/lib/ReactCore_Internal.re
@@ -480,7 +480,7 @@ module Make = (OutputTree: OutputTree) => {
       'state 'action 'elementType 'outputNode.
       instance('state, 'action, 'elementType, 'outputNode) => bool
      =
-      instance => Slots.flushPendingUpdates(instance.slots);
+      instance => Hooks.flushPendingUpdates(instance.slots);
 
     type childElementUpdate = {
       updatedRenderedElement: renderedElement,

--- a/core/lib/RemoteAction.re
+++ b/core/lib/RemoteAction.re
@@ -1,8 +1,19 @@
-type t('action) = {mutable send: 'action => unit};
-let sendDefault = _action => ();
-let create = () => {send: sendDefault};
-let subscribe = (~send, x) =>
-  if (x.send === sendDefault) {
-    x.send = send;
+type t('action) = {mutable subscribers: list('action => unit)};
+
+type unsubscribe = unit => unit;
+
+let create = () => {subscribers: []};
+
+let subscribe = (~handler: 'action => unit, {subscribers} as emitter: t('a)) => {
+  if (!List.exists(f => f === handler, subscribers)) {
+    emitter.subscribers = [handler, ...subscribers];
+  }
+  let unsubscribe = () => {
+    emitter.subscribers = List.filter(f => f !== f, subscribers);
   };
-let send = (x, ~action) => x.send(action);
+  unsubscribe;
+};
+
+let send = (~action: 'a, emitter: t('a)) => {
+  List.iter(c => c(action), emitter.subscribers);
+}

--- a/core/lib/RemoteAction.re
+++ b/core/lib/RemoteAction.re
@@ -1,0 +1,8 @@
+type t('action) = {mutable send: 'action => unit};
+let sendDefault = _action => ();
+let create = () => {send: sendDefault};
+let subscribe = (~send, x) =>
+  if (x.send === sendDefault) {
+    x.send = send;
+  };
+let send = (x, ~action) => x.send(action);

--- a/core/lib/RemoteAction.rei
+++ b/core/lib/RemoteAction.rei
@@ -11,8 +11,10 @@ type t('action);
 /*** Create a new remote action, to which one component will subscribe. */
 let create: unit => t('action);
 
+type unsubscribe = unit => unit;
+
 /*** Subscribe to the remote action, via the component's `act` function. */
-let subscribe: (~send: 'action => unit, t('action)) => unit;
+let subscribe: (~handler: 'action => unit, t('action)) => unsubscribe;
 
 /*** Perform an action on the subscribed component. */
-let send: (t('action), ~action: 'action) => unit;
+let send: (~action: 'action, t('action)) => unit;

--- a/core/lib/RemoteAction.rei
+++ b/core/lib/RemoteAction.rei
@@ -1,0 +1,18 @@
+/***
+ * RemoteAction provides a way to send actions to a remote component.
+ * The sender creates a fresh RemoteAction and passes it down.
+ * The recepient component calls subscribe.
+ * The caller can then send actions to the recipient components via act.
+ * This mechanism is useful in places where you'd normally use methods
+ * on a ref.
+ */
+type t('action);
+
+/*** Create a new remote action, to which one component will subscribe. */
+let create: unit => t('action);
+
+/*** Subscribe to the remote action, via the component's `act` function. */
+let subscribe: (~send: 'action => unit, t('action)) => unit;
+
+/*** Perform an action on the subscribed component. */
+let send: (t('action), ~action: 'action) => unit;

--- a/core/lib/Slots.re
+++ b/core/lib/Slots.re
@@ -1,0 +1,83 @@
+type slotInternal('slot, 'nextSlots) = {
+  flush: unit => ('slot, bool),
+  this: 'slot,
+  next: 'nextSlots,
+};
+
+type t('slot, 'nextSlots) = ref(option(slotInternal('slot, 'nextSlots)));
+
+type empty = t(unit, unit);
+
+let create = () => ref(None);
+
+let flushPendingUpdatesInternal = (default, slots) =>
+  switch (slots) {
+  | Some({flush}) => flush()
+  | None => (default, false)
+  };
+
+let flushPendingUpdates = slots =>
+  switch (slots^) {
+  | Some({flush}) => snd(flush())
+  | None => false
+  };
+
+let shouldUpdate = (slots, newValue) =>
+  switch (slots) {
+  | Some({this}) => this !== newValue
+  | None => true
+  };
+
+let stabilized = (this, nextSlots) => {
+  this,
+  next: nextSlots,
+  flush: () => (this, false),
+};
+
+let makeSetter =
+    (~flushed, ~default, ~latestSlotsRef, ~nextSlots, makeNewValue) => {
+  let prevSlots = latestSlotsRef^;
+  latestSlotsRef :=
+    Some({
+      ...flushed,
+      flush: () => {
+        let prevValue = fst(flushPendingUpdatesInternal(default, prevSlots));
+        let newValue = makeNewValue(prevValue);
+        let shouldUpdate = shouldUpdate(prevSlots, newValue);
+        latestSlotsRef := Some(stabilized(newValue, flushed.next));
+        (newValue, flushPendingUpdates(nextSlots) || shouldUpdate);
+      },
+    });
+};
+
+let use = (~default, slots: t(_)) =>
+  switch (slots^) {
+  | None =>
+    let nextSlots = create();
+    let slot = stabilized(default, nextSlots);
+    slots := Some(slot);
+    (
+      (
+        slot.this,
+        makeSetter(
+          ~flushed=slot,
+          ~default,
+          ~latestSlotsRef=slots,
+          ~nextSlots,
+        ),
+      ),
+      nextSlots,
+    );
+  | Some(slot) => (
+      (
+        slot.this,
+        makeSetter(
+          ~flushed=slot,
+          ~default,
+          ~latestSlotsRef=slots,
+          ~nextSlots=slot.next,
+        ),
+      ),
+      slot.next,
+    )
+  };

--- a/core/lib/Slots.rei
+++ b/core/lib/Slots.rei
@@ -1,8 +1,24 @@
-type t('slot, 'nextSlots);
-let create: unit => t('slot, 'nextSlots);
-let use:
-  (~default: 'slot, t('slot, t('slot2, 'nextSlots))) =>
-  (('slot, ('slot => 'slot) => unit), t('slot2, 'nextSlots));
-let flushPendingUpdates: t('slot, 'nextSlots) => bool;
+module type Elem = {type t('a);};
 
-type empty = t(unit, unit);
+module type S = {
+  type elem('a);
+  type opaqueElement =
+    | Any(elem('a)): opaqueElement;
+  type t('slot, 'nextSlots);
+  type empty = t(unit, unit);
+
+  let create: unit => t('slot, 'nextSlots);
+  let use:
+    (~default: elem('slot), t('slot, t('slot2, 'nextSlots))) =>
+    (
+      (elem('slot), (elem('slot) => elem('slot)) => unit),
+      t('slot2, 'nextSlots),
+    );
+
+  let fold:
+    ((opaqueElement, 'a, ~flush: unit => bool) => 'a, 'a, t('b, 'c)) => 'a;
+};
+
+module Make: (Elem: Elem) => S with type elem('a) = Elem.t('a);
+
+include S with type elem('a) = 'a;

--- a/core/lib/Slots.rei
+++ b/core/lib/Slots.rei
@@ -1,9 +1,9 @@
-module type Elem = {type t('a);};
+module type Witness = {type t('a);};
 
 module type S = {
-  type elem('a);
-  type opaqueElement =
-    | Any(elem('a)): opaqueElement;
+  type witness('a);
+  type opaqueValue =
+    | Any(witness('a)): opaqueValue;
   type t('slot, 'nextSlots);
   type empty = t(unit, unit);
 
@@ -11,15 +11,15 @@ module type S = {
   let use:
     (
       ~default: unit => 'slot,
-      ~toElem: 'slot => elem('slot),
+      ~toWitness: 'slot => witness('slot),
       t('slot, t('slot2, 'nextSlots))
     ) =>
     ('slot, t('slot2, 'nextSlots));
 
   let fold:
-    ((opaqueElement, 'acc) => 'acc, 'acc, t('slots, 'nextSlots)) => 'acc;
+    ((opaqueValue, 'acc) => 'acc, 'acc, t('slots, 'nextSlots)) => 'acc;
 };
 
-module Make: (Elem: Elem) => S with type elem('a) = Elem.t('a);
+module Make: (Witness: Witness) => S with type witness('a) = Witness.t('a);
 
-include S with type elem('a) = 'a;
+include S with type witness('a) = 'a;

--- a/core/lib/Slots.rei
+++ b/core/lib/Slots.rei
@@ -16,7 +16,12 @@ module type S = {
     );
 
   let fold:
-    ((opaqueElement, 'a, ~flush: unit => bool) => 'a, 'a, t('b, 'c)) => 'a;
+    (
+      (opaqueElement, 'acc, ~flush: unit => bool) => 'acc,
+      'acc,
+      t('slots, 'nextSlots)
+    ) =>
+    'acc;
 };
 
 module Make: (Elem: Elem) => S with type elem('a) = Elem.t('a);

--- a/core/lib/Slots.rei
+++ b/core/lib/Slots.rei
@@ -1,0 +1,8 @@
+type t('slot, 'nextSlots);
+let create: unit => t('slot, 'nextSlots);
+let use:
+  (~default: 'slot, t('slot, t('slot2, 'nextSlots))) =>
+  (('slot, ('slot => 'slot) => unit), t('slot2, 'nextSlots));
+let flushPendingUpdates: t('slot, 'nextSlots) => bool;
+
+type empty = t(unit, unit);

--- a/core/lib/Slots.rei
+++ b/core/lib/Slots.rei
@@ -9,19 +9,15 @@ module type S = {
 
   let create: unit => t('slot, 'nextSlots);
   let use:
-    (~default: elem('slot), t('slot, t('slot2, 'nextSlots))) =>
     (
-      (elem('slot), (elem('slot) => elem('slot)) => unit),
-      t('slot2, 'nextSlots),
-    );
+      ~default: unit => 'slot,
+      ~toElem: 'slot => elem('slot),
+      t('slot, t('slot2, 'nextSlots))
+    ) =>
+    ('slot, t('slot2, 'nextSlots));
 
   let fold:
-    (
-      (opaqueElement, 'acc, ~flush: unit => bool) => 'acc,
-      'acc,
-      t('slots, 'nextSlots)
-    ) =>
-    'acc;
+    ((opaqueElement, 'acc) => 'acc, 'acc, t('slots, 'nextSlots)) => 'acc;
 };
 
 module Make: (Elem: Elem) => S with type elem('a) = Elem.t('a);

--- a/core/test/Assert.re
+++ b/core/test/Assert.re
@@ -130,6 +130,7 @@ let flushPendingUpdates = ({renderedElement, syntheticElement}) => {
 
 let executeSideEffects = ({renderedElement} as testState) => {
   RenderedElement.executeHostViewUpdates(renderedElement) |> ignore;
+  List.iter(f => f(), renderedElement.enqueuedEffects);
   testState;
 };
 

--- a/core/test/Assert.re
+++ b/core/test/Assert.re
@@ -146,6 +146,10 @@ let expect = (~label=?, expected, testState) => {
   reset(testState);
 };
 
+let expectInt = (~label, expected, actual) => {
+    Alcotest.(check(int))(label, expected, actual);
+};
+
 let act = (~action, rAction, testState) => {
   RemoteAction.send(rAction, ~action);
   testState;

--- a/core/test/Assert.re
+++ b/core/test/Assert.re
@@ -123,10 +123,16 @@ let update =
     ),
 };
 
-let flushPendingUpdates = ({renderedElement, syntheticElement}) => {
-  syntheticElement,
-  renderedElement: RenderedElement.flushPendingUpdates(renderedElement),
-};
+let flushPendingUpdates = ({renderedElement, syntheticElement} as testState) =>
+  Implementation.isDirty^ ?
+    {
+      Implementation.isDirty := false;
+      {
+        syntheticElement,
+        renderedElement: RenderedElement.flushPendingUpdates(renderedElement),
+      };
+    } :
+    testState;
 
 let executeSideEffects = ({renderedElement} as testState) => {
   RenderedElement.executeHostViewUpdates(renderedElement) |> ignore;

--- a/core/test/Assert.re
+++ b/core/test/Assert.re
@@ -136,8 +136,11 @@ let flushPendingUpdates = ({renderedElement, syntheticElement} as testState) =>
 
 let executeSideEffects = ({renderedElement} as testState) => {
   RenderedElement.executeHostViewUpdates(renderedElement) |> ignore;
-  List.iter(f => f(), renderedElement.enqueuedEffects);
-  testState;
+
+  {
+    ...testState,
+    renderedElement: RenderedElement.executePendingEffects(renderedElement),
+  };
 };
 
 let expect = (~label=?, expected, testState) => {

--- a/core/test/Assert.re
+++ b/core/test/Assert.re
@@ -140,6 +140,6 @@ let expect = (~label=?, expected, testState) => {
 };
 
 let act = (~action, rAction, testState) => {
-  RemoteAction.act(rAction, ~action);
+  RemoteAction.send(rAction, ~action);
   testState;
 };

--- a/core/test/Components.re
+++ b/core/test/Components.re
@@ -100,8 +100,8 @@ module BoxList = {
     | Reverse;
   let component = component("BoxList");
   let make = (~rAction, ~useDynamicKeys=false, _children) =>
-    component(slots => {
-      let (state, dispatch, _slots: Hooks.empty) =
+    component(hooks => {
+      let (state, dispatch, hooks) =
         Hooks.reducer(
           ~initialState=[],
           (action, state) =>
@@ -112,9 +112,15 @@ module BoxList = {
               ]
             | Reverse => List.rev(state)
             },
-          slots,
+          hooks,
         );
-      RemoteAction.subscribe(~send=dispatch, rAction);
+      let _: Hooks.empty =
+        Hooks.effect(
+          OnMount,
+          () => Some(RemoteAction.subscribe(~handler=dispatch, rAction)),
+          hooks,
+        );
+
       listToElement(state);
     });
   let createElement = (~rAction, ~useDynamicKeys=false, ~children, ()) =>
@@ -158,8 +164,8 @@ module UpdateAlternateClicks = {
     | Click;
   let component = component("UpdateAlternateClicks");
   let make = (~rAction, _children) =>
-    component(slots => {
-      let (state, dispatch, _slots: Hooks.empty) =
+    component(hooks => {
+      let (state, dispatch, hooks) =
         Hooks.reducer(
           ~initialState=ref(0),
           (Click, state) =>
@@ -170,9 +176,14 @@ module UpdateAlternateClicks = {
                 state;
               } :
               ref(state^ + 1),
-          slots,
+          hooks,
         );
-      RemoteAction.subscribe(~send=dispatch, rAction);
+      let _: Hooks.empty =
+        Hooks.effect(
+          OnMount,
+          () => Some(RemoteAction.subscribe(~handler=dispatch, rAction)),
+          hooks,
+        );
       stringToElement(string_of_int(state^));
     });
   let createElement = (~rAction, ~children as _, ()) =>
@@ -184,10 +195,15 @@ module ToggleClicks = {
     | Click;
   let component = component("ToggleClicks");
   let make = (~rAction, _children) =>
-    component(slots => {
-      let (state, dispatch, _slots: Hooks.empty) =
-        Hooks.reducer(~initialState=false, (Click, state) => !state, slots);
-      RemoteAction.subscribe(~send=dispatch, rAction);
+    component(hooks => {
+      let (state, dispatch, hooks) =
+        Hooks.reducer(~initialState=false, (Click, state) => !state, hooks);
+      let _: Hooks.empty =
+        Hooks.effect(
+          OnMount,
+          () => Some(RemoteAction.subscribe(~handler=dispatch, rAction)),
+          hooks,
+        );
       if (state) {
         <Div> <Text title="cell1" /> <Text title="cell2" /> </Div>;
       } else {

--- a/core/test/Components.re
+++ b/core/test/Components.re
@@ -4,35 +4,31 @@ open TestReactCore;
  * The simplest component. Composes nothing!
  */
 module Box = {
-  let component = statefulNativeComponent("Box");
-  let make = (~title="ImABox", ~onClick as _=?, _children) => {
-    ...component,
-    initialState: () => title,
-    willReceiveProps: _ => title,
-    printState: _ => title,
-    render: _ => {
-      children: listToElement([]),
-      make: () => Implementation.{name: "Box", element: Text(title)},
-      updateInstance: (_, _) => Implementation.{name: "Box", element: Text(title)},
-      shouldReconfigureInstance: (~oldState, ~newState) =>
-        oldState != newState,
-    },
-  };
+  let component = nativeComponent("Box");
+  let make = (~title="ImABox", ~onClick as _=?, _children) =>
+    component((_: Slots.empty) =>
+      {
+        children: listToElement([]),
+        make: () => Implementation.{name: "Box", element: Text(title)},
+        configureInstance: (~isFirstRender, instance) =>
+          isFirstRender ?
+            instance : Implementation.{name: "Box", element: Text(title)},
+      }
+    );
   let createElement = (~key=?, ~title=?, ~children as _children, ()) =>
     element(~key?, make(~title?, ()));
 };
 
 module Div = {
-  let component = statelessNativeComponent("Div");
-  let make = children => {
-    ...component,
-    render: _ => {
-      children: listToElement(children),
-      make: () => Implementation.{name: "Div", element: View},
-      updateInstance: (_, d) => d,
-      shouldReconfigureInstance: (~oldState as _, ~newState as _) => false,
-    },
-  };
+  let component = nativeComponent("Div");
+  let make = children =>
+    component((_: Slots.empty) =>
+      {
+        make: () => Implementation.{name: "Div", element: View},
+        configureInstance: (~isFirstRender as _, d) => d,
+        children: listToElement(children),
+      }
+    );
   let createElement = (~key=?, ~children, ()) =>
     element(~key?, make(children));
 };
@@ -42,34 +38,28 @@ module Text = {
     current: string,
     prev: string,
   };
-  let component = statefulNativeComponent("Text");
-  let shouldUpdate = (!=);
-  let make = (~title="ImABox", _children) => {
-    ...component,
-    initialState: () => {current: title, prev: title},
-    willReceiveProps: ({state: {current}}) => {
-      current: title,
-      prev: current,
-    },
-    shouldUpdate:
-      ({oldSelf: {state: oldState}, newSelf: {state: newState}}) =>
-      shouldUpdate(oldState, newState),
-    printState: _ => "",
-    render: _ => {
-      children: listToElement([]),
-      make: () => Implementation.{name: "Text", element: Text(title)},
-      updateInstance: ({state: {current, prev}}, t) => {
-        Implementation.mountLog :=
-          [
-            Implementation.ChangeText(prev, current),
-            ...Implementation.mountLog^,
-          ];
-        t;
-      },
-      shouldReconfigureInstance: (~oldState, ~newState) =>
-        shouldUpdate(oldState, newState),
-    },
-  };
+  let component = nativeComponent("Text");
+  let make = (~title="ImABox", _children) =>
+    component(slots => {
+      let (prevTitle, setTitle, _slots: Slots.t(unit, unit)) =
+        Hooks.useRef(title, slots);
+      /* let _slots = Hooks.useEffect(() => setTitle(title), slots); */
+      {
+        make: () => Implementation.{name: "Text", element: Text(title)},
+        configureInstance: (~isFirstRender, t) => {
+          if (prevTitle != title || isFirstRender) {
+            Implementation.mountLog :=
+              [
+                Implementation.ChangeText(prevTitle, title),
+                ...Implementation.mountLog^,
+              ];
+            setTitle(title);
+          };
+          t;
+        },
+        children: listToElement([]),
+      };
+    });
   let createElement = (~key=?, ~title=?, ~children as _children, ()) =>
     element(~key?, make(~title?, ()));
 };
@@ -77,16 +67,12 @@ module Text = {
 let stringToElement = string => <Text title=string />;
 
 module BoxWrapper = {
-  let component = statelessComponent("BoxWrapper");
-  let make =
-      (~title="ImABox", ~twoBoxes=false, ~onClick as _=?, _children)
-      : syntheticComponentSpec(stateless, unit) => {
-    ...component,
-    initialState: () => (),
-    render: _self =>
+  let component = component("BoxWrapper");
+  let make = (~title="ImABox", ~twoBoxes=false, ~onClick as _=?, _children) =>
+    component((_: Slots.t(unit, unit)) =>
       twoBoxes ?
-        <Div> <Box title /> <Box title /> </Div> : <Div> <Box title /> </Div>,
-  };
+        <Div> <Box title /> <Box title /> </Div> : <Div> <Box title /> </Div>
+    );
   let createElement = (~key=?, ~title=?, ~twoBoxes=?, ~children as _, ()) =>
     element(~key?, make(~title?, ~twoBoxes?, ~onClick=(), ()));
 };
@@ -95,12 +81,9 @@ module BoxWrapper = {
  * Box with dynamic keys.
  */
 module BoxItemDynamic = {
-  let component = statelessComponent(~useDynamicKey=true, "BoxItemDynamic");
-  let make = (~title="ImABox", _children: list(syntheticElement)) => {
-    ...component,
-    printState: _ => title,
-    render: _self => stringToElement(title),
-  };
+  let component = component(~useDynamicKey=true, "BoxItemDynamic");
+  let make = (~title="ImABox", _children: list(syntheticElement)) =>
+    component((_: Slots.t(unit, unit)) => stringToElement(title));
   let createElement = (~title, ~children, ()) =>
     element(make(~title, children));
 };
@@ -109,99 +92,59 @@ module BoxList = {
   type action =
     | Create(string)
     | Reverse;
-  let component = reducerComponent("BoxList");
-  let make = (~rAction, ~useDynamicKeys=false, _children) => {
-    ...component,
-    initialState: () => [],
-    reducer: (action, state) =>
-      switch (action) {
-      | Create(title) =>
-        Update([
-          useDynamicKeys ? <BoxItemDynamic title /> : <Box title />,
-          ...state,
-        ])
-      | Reverse => Update(List.rev(state))
-      },
-    render: ({state, act}) => {
-      RemoteAction.subscribe(~act, rAction);
+  let component = component("BoxList");
+  let make = (~rAction, ~useDynamicKeys=false, _children) =>
+    component(slots => {
+      let (state, dispatch, _slots: Slots.empty) =
+        Hooks.useReducer(
+          ~initialState=[],
+          (action, state) =>
+            switch (action) {
+            | Create(title) =>
+              print_endline(string_of_int(List.length(state)));
+              [
+                useDynamicKeys ? <BoxItemDynamic title /> : <Box title />,
+                ...state,
+              ];
+            | Reverse => List.rev(state)
+            },
+          slots,
+        );
+      RemoteAction.subscribe(~send=dispatch, rAction);
       listToElement(state);
-    },
-  };
+    });
   let createElement = (~rAction, ~useDynamicKeys=false, ~children, ()) =>
     element(make(~rAction, ~useDynamicKeys, children));
 };
 
-/**
- * This component demonstrates several things:
- *
- * 1. Demonstration of making internal state hidden / abstract. Components
- * should encapsulate their state representation and should be free to change
- * it.
- *
- * 2. Demonstrates an equivalent of `componentWillReceiveProps`.
- * `componentWillReceiveProps` is like an "edge trigger" on props, and the
- * first item of the tuple shows how we implement that with this API.
- */
-module ChangeCounter = {
-  type state = {
-    numChanges: int,
-    mostRecentLabel: string,
-  };
-  let component = reducerComponent("ChangeCounter");
-  let make = (~label, _children) => {
-    ...component,
-    initialState: () => {mostRecentLabel: label, numChanges: 0},
-    reducer: ((), state) =>
-      Update({...state, numChanges: state.numChanges + 10}),
-    willReceiveProps: ({state, reduce}) =>
-      label != state.mostRecentLabel ?
-        {
-          reduce(() => (), ());
-          reduce(() => (), ());
-          {mostRecentLabel: label, numChanges: state.numChanges + 1};
-        } :
-        state,
-    render: ({state: {numChanges: _, mostRecentLabel: _}}) =>
-      listToElement([]),
-    printState: ({numChanges, mostRecentLabel}) =>
-      "[" ++ string_of_int(numChanges) ++ ", " ++ mostRecentLabel ++ "]",
-  };
-  let createElement = (~label, ~children as _, ()) =>
-    element(make(~label, ()));
-};
-
 module StatelessButton = {
-  let component = statelessComponent("StatelessButton");
+  let component = component("StatelessButton");
   let make =
-      (~initialClickCount as _="noclicks", ~test as _="default", _children) => {
-    ...component,
-    render: _self => <Div />,
-  };
+      (~initialClickCount as _="noclicks", ~test as _="default", _children) =>
+    component((_: Slots.empty) => <Div />);
   let createElement = (~initialClickCount=?, ~test=?, ~children as _, ()) =>
     element(make(~initialClickCount?, ~test?, ()));
 };
 
 module ButtonWrapper = {
-  type state = {buttonWrapperState: int};
-  let component = statelessComponent("ButtonWrapper");
-  let make = (~wrappedText="default", _children) => {
-    ...component,
-    render: ({state: _}) =>
+  let component = component("ButtonWrapper");
+  let make = (~wrappedText="default", _children) =>
+    component((_: Slots.empty) =>
       <StatelessButton
         initialClickCount={"wrapped:" ++ wrappedText ++ ":wrapped"}
-      />,
-  };
+      />
+    );
   let createElement = (~wrappedText=?, ~children as _, ()) =>
     element(make(~wrappedText?, ()));
 };
 
 module ButtonWrapperWrapper = {
   let buttonWrapperJsx = <ButtonWrapper wrappedText="TestButtonUpdated!!!" />;
-  let component = statelessComponent("ButtonWrapperWrapper");
-  let make = (~wrappedText="default", _children) => {
-    ...component,
-    render: _ => <Div> {stringToElement(wrappedText)} buttonWrapperJsx </Div>,
-  };
+  let component = component("ButtonWrapperWrapper");
+  let make = (~wrappedText="default", _children) =>
+    component((_: Slots.empty) =>
+      <Div> {stringToElement(wrappedText)} buttonWrapperJsx </Div>
+    );
   let createElement = (~wrappedText=?, ~children as _, ()) =>
     element(make(~wrappedText?, ()));
 };
@@ -209,18 +152,28 @@ module ButtonWrapperWrapper = {
 module UpdateAlternateClicks = {
   type action =
     | Click;
-  let component = reducerComponent("UpdateAlternateClicks");
-  let make = (~rAction, _children) => {
-    ...component,
-    initialState: () => 0,
-    printState: state => string_of_int(state),
-    reducer: (Click, state) => Update(state + 1),
-    shouldUpdate: ({newSelf: {state}}) => state mod 2 === 0,
-    render: ({state, act}) => {
-      RemoteAction.subscribe(~act, rAction);
-      stringToElement(string_of_int(state));
-    },
-  };
+  let component = component("UpdateAlternateClicks");
+  let make = (~rAction, _children) =>
+    component(slots => {
+      let (state, dispatch, _slots: Slots.empty) =
+        Hooks.useReducer(
+          ~initialState=ref(0),
+          (Click, state) => {
+            print_endline(string_of_int(state^));
+            /* FIXME: make this pure */
+            state^ mod 2 === 0 ?
+              {
+                print_endline("AKI");
+                state := state^ + 1;
+                state;
+              } :
+              ref(state^ + 1)
+          },
+          slots,
+        );
+      RemoteAction.subscribe(~send=dispatch, rAction);
+      stringToElement(string_of_int(state^));
+    });
   let createElement = (~rAction, ~children as _, ()) =>
     element(make(~rAction, ()));
 };
@@ -228,21 +181,29 @@ module UpdateAlternateClicks = {
 module ToggleClicks = {
   type action =
     | Click;
-  let component = reducerComponent("ToggleClicks");
-  let make = (~rAction, _children) => {
-    ...component,
-    initialState: () => false,
-    printState: state => string_of_bool(state),
-    reducer: (Click, state) => Update(!state),
-    render: ({state, act}) => {
-      RemoteAction.subscribe(~act, rAction);
+  let component = component("ToggleClicks");
+  let make = (~rAction, _children) =>
+    component(slots => {
+      let (state, dispatch, _slots: Slots.empty) =
+        Hooks.useReducer(
+          ~initialState=false,
+          (Click, state) => !state,
+          slots,
+        );
+      RemoteAction.subscribe(~send=dispatch, rAction);
       if (state) {
         <Div> <Text title="cell1" /> <Text title="cell2" /> </Div>;
       } else {
         <Div> <Text title="well" /> </Div>;
       };
-    },
-  };
+    });
   let createElement = (~rAction, ~children as _, ()) =>
     element(make(~rAction, ()));
+};
+
+module EmptyComponent = {
+  let component = component("Box");
+  let make = _children => component((_: Slots.empty) => listToElement([]));
+  let createElement = (~key=?, ~children as _children, ()) =>
+    element(~key?, make());
 };

--- a/core/test/Components.re
+++ b/core/test/Components.re
@@ -101,7 +101,6 @@ module BoxList = {
           (action, state) =>
             switch (action) {
             | Create(title) =>
-              print_endline(string_of_int(List.length(state)));
               [
                 useDynamicKeys ? <BoxItemDynamic title /> : <Box title />,
                 ...state,
@@ -159,11 +158,9 @@ module UpdateAlternateClicks = {
         Hooks.useReducer(
           ~initialState=ref(0),
           (Click, state) => {
-            print_endline(string_of_int(state^));
             /* FIXME: make this pure */
             state^ mod 2 === 0 ?
               {
-                print_endline("AKI");
                 state := state^ + 1;
                 state;
               } :

--- a/core/test/Components.re
+++ b/core/test/Components.re
@@ -204,3 +204,29 @@ module EmptyComponent = {
   let createElement = (~key=?, ~children as _children, ()) =>
     element(~key?, make());
 };
+
+module EmptyComponentWithAlwaysEffect = {
+  let component = component("Box");
+  let make = (~onEffect, ~onEffectDispose, _children) => component((slots) => {
+      let _slots: Hooks.empty = Hooks.effect(Always, () => {
+        onEffect(); 
+        Some(onEffectDispose);
+      }, slots);
+      listToElement([])
+  });
+  let createElement = (~key=?, ~children as _children, ~onEffect, ~onEffectDispose, ()) =>
+    element(~key?, make(~onEffect, ~onEffectDispose, _children));
+};
+
+/* module EmptyComponentWithAlwaysEffect = { */
+/*   let component = component("Box"); */
+/*   let make = (~onEffect, ~onEffectDispose, _children) => component((slots: Hooks.empty) => { */
+/*       let _slots: Hooks.empty = Hooks.effect(Always, () => { */
+/*         onEffect(); */ 
+/*         Some(onEffectDispose); */
+/*       }, slots); */
+/*       listToElement([]) */
+/*   }); */
+/*   let createElement = (~key=?, ~children as _children, ()) => */
+/*     element(~key?, make()); */
+/* }; */

--- a/core/test/Components.re
+++ b/core/test/Components.re
@@ -218,15 +218,15 @@ module EmptyComponentWithAlwaysEffect = {
     element(~key?, make(~onEffect, ~onEffectDispose, _children));
 };
 
-/* module EmptyComponentWithAlwaysEffect = { */
-/*   let component = component("Box"); */
-/*   let make = (~onEffect, ~onEffectDispose, _children) => component((slots: Hooks.empty) => { */
-/*       let _slots: Hooks.empty = Hooks.effect(Always, () => { */
-/*         onEffect(); */ 
-/*         Some(onEffectDispose); */
-/*       }, slots); */
-/*       listToElement([]) */
-/*   }); */
-/*   let createElement = (~key=?, ~children as _children, ()) => */
-/*     element(~key?, make()); */
-/* }; */
+module EmptyComponentWithOnMountEffect = {
+  let component = component("Box");
+  let make = (~onEffect, ~onEffectDispose, _children) => component((slots) => {
+      let _slots: Hooks.empty = Hooks.effect(OnMount, () => {
+        onEffect(); 
+        Some(onEffectDispose);
+      }, slots);
+      listToElement([])
+  });
+  let createElement = (~key=?, ~children as _children, ~onEffect, ~onEffectDispose, ()) =>
+    element(~key?, make(~onEffect, ~onEffectDispose, _children));
+};

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -160,7 +160,7 @@ let core = [
       let well = text("well");
 
       let testState =
-        render(Components.(<Div><ToggleClicks rAction /></Div>))
+        render(Components.(<Div> <ToggleClicks rAction /> </Div>))
         |> executeSideEffects
         |> expect(
              ~label="It constructs the initial tree",
@@ -185,6 +185,7 @@ let core = [
            ~label="It replaces text(well) with text(cell1) and text(cell2)",
            [
              Implementation.BeginChanges,
+             UnmountChild(div, well),
              ChangeText("cell1", "cell1"),
              MountChild(div, cell1, 0),
              ChangeText("cell2", "cell2"),

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -181,14 +181,10 @@ let core = [
       testState
       |> flushPendingUpdates
       |> executeSideEffects
-      /* BUG:
-       * This expectation fails when there is a top-level `<Div>` element
-       */
       |> expect(
            ~label="It replaces text(well) with text(cell1) and text(cell2)",
            [
              Implementation.BeginChanges,
-             UnmountChild(div, well),
              ChangeText("cell1", "cell1"),
              MountChild(div, cell1, 0),
              ChangeText("cell2", "cell2"),

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -689,6 +689,44 @@ let core = [
       |> ignore;
     },
   ),
+  (
+    "Test 'always' effect",
+    `Quick,
+    () => {
+      let effectCallCount = ref(0);
+      let effectDisposeCallCount = ref(0);
+      let onEffect = () => effectCallCount := effectCallCount^ + 1;
+      let onEffectDispose = () => effectDisposeCallCount := effectDisposeCallCount^ + 1;
+
+      let testState = render(<Components.EmptyComponentWithAlwaysEffect onEffect onEffectDispose />)
+      |> executeSideEffects;
+
+      expectInt(
+           ~label="The effect should've been run",
+           effectCallCount^,
+           1
+         );
+
+      expectInt(~label="The dispose should not have been run yet",
+            effectDisposeCallCount^,
+            0);
+
+      testState
+      |> update(<Components.EmptyComponentWithAlwaysEffect onEffect onEffectDispose />)
+      |> executeSideEffects
+      |> ignore;
+
+      expectInt(
+           ~label="The effect should've been run again",
+           effectCallCount^,
+           2
+         );
+
+      expectInt(~label="The effect dispose callback should have been run",
+            effectDisposeCallCount^,
+            1);
+    }
+  ),
 ];
 
 /** Annoying dune progress */

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -174,7 +174,7 @@ let core = [
              ],
            );
 
-      RemoteAction.act(~action=Components.ToggleClicks.Click, rAction);
+      RemoteAction.send(~action=Components.ToggleClicks.Click, rAction);
       /* TODO: Bring back! */
       /* let cell1 = text("cell1"); */
       /* let cell2 = text("cell2"); */

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -175,23 +175,24 @@ let core = [
            );
 
       RemoteAction.send(~action=Components.ToggleClicks.Click, rAction);
-      /* TODO: Bring back! */
-      /* let cell1 = text("cell1"); */
-      /* let cell2 = text("cell2"); */
+      let cell1 = text("cell1");
+      let cell2 = text("cell2");
 
       testState
       |> flushPendingUpdates
       |> executeSideEffects
+      /* BUG:
+       * This expectation fails when there is a top-level `<Div>` element
+       */
       |> expect(
            ~label="It replaces text(well) with text(cell1) and text(cell2)",
            [
              Implementation.BeginChanges,
-             /* TODO: Fix - we should see these updates occur! */
-             /* UnmountChild(div, well), */
-             /* ChangeText("cell1", "cell1"), */
-             /* MountChild(div, cell1, 0), */
-             /* ChangeText("cell2", "cell2"), */
-             /* MountChild(div, cell2, 1), */
+             UnmountChild(div, well),
+             ChangeText("cell1", "cell1"),
+             MountChild(div, cell1, 0),
+             ChangeText("cell2", "cell2"),
+             MountChild(div, cell2, 1),
              CommitChanges,
            ],
          )

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -799,11 +799,13 @@ let core = [
            effectCallCount^
          );
 
-      /* TODO: FIX ME */
-      /* expectInt(~label="The effect dispose callback should have been called since the component was un-mounted.", */
-      /*       1, */
-      /*       effectDisposeCallCount^); */
-    }
+      expectInt(
+        ~label=
+          "The effect dispose callback should have been called since the component was un-mounted.",
+        1,
+        effectDisposeCallCount^,
+      );
+    },
   ),
   (
     "Test 'OnMount' effect in nested component",

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -152,6 +152,53 @@ let core = [
       |> ignore,
   ),
   (
+    "Test subtree replace elements (not at top-level)",
+    `Quick,
+    () => {
+      let rAction = RemoteAction.create();
+
+      let well = text("well");
+
+      let testState =
+        render(Components.(<Div><ToggleClicks rAction /></Div>))
+        |> executeSideEffects
+        |> expect(
+             ~label="It constructs the initial tree",
+             [
+               Implementation.BeginChanges,
+               ChangeText("well", "well"),
+               MountChild(div, well, 0),
+               MountChild(div, div, 0),
+               MountChild(root, div, 0),
+               CommitChanges,
+             ],
+           );
+
+      RemoteAction.act(~action=Components.ToggleClicks.Click, rAction);
+      /* TODO: Bring back! */
+      /* let cell1 = text("cell1"); */
+      /* let cell2 = text("cell2"); */
+
+      testState
+      |> flushPendingUpdates
+      |> executeSideEffects
+      |> expect(
+           ~label="It replaces text(well) with text(cell1) and text(cell2)",
+           [
+             Implementation.BeginChanges,
+             /* TODO: Fix - we should see these updates occur! */
+             /* UnmountChild(div, well), */
+             /* ChangeText("cell1", "cell1"), */
+             /* MountChild(div, cell1, 0), */
+             /* ChangeText("cell2", "cell2"), */
+             /* MountChild(div, cell2, 1), */
+             CommitChanges,
+           ],
+         )
+      |> ignore;
+    },
+  ),
+  (
     "Test subtree replace elements",
     `Quick,
     () => {

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -690,11 +690,12 @@ let core = [
     },
   ),
   (
-    "Test 'always' effect",
+    "Test 'Always' effect",
     `Quick,
     () => {
       let effectCallCount = ref(0);
       let effectDisposeCallCount = ref(0);
+
       let onEffect = () => effectCallCount := effectCallCount^ + 1;
       let onEffectDispose = () => effectDisposeCallCount := effectDisposeCallCount^ + 1;
 
@@ -703,13 +704,12 @@ let core = [
 
       expectInt(
            ~label="The effect should've been run",
-           effectCallCount^,
-           1
-         );
+           1,
+           effectCallCount^);
 
       expectInt(~label="The dispose should not have been run yet",
-            effectDisposeCallCount^,
-            0);
+            0,
+            effectDisposeCallCount^);
 
       testState
       |> update(<Components.EmptyComponentWithAlwaysEffect onEffect onEffectDispose />)
@@ -718,13 +718,118 @@ let core = [
 
       expectInt(
            ~label="The effect should've been run again",
-           effectCallCount^,
-           2
-         );
+           2,
+           effectCallCount^);
 
       expectInt(~label="The effect dispose callback should have been run",
-            effectDisposeCallCount^,
-            1);
+            1,
+            effectDisposeCallCount^);
+    }
+  ),
+  (
+    "Test 'Always' effect in a nested component",
+    `Quick,
+    () => {
+      let effectCallCount = ref(0);
+      let effectDisposeCallCount = ref(0);
+      let onEffect = () => effectCallCount := effectCallCount^ + 1;
+      let onEffectDispose = () => effectDisposeCallCount := effectDisposeCallCount^ + 1;
+
+      render(
+        Components.(
+          <Div> <EmptyComponentWithAlwaysEffect onEffect onEffectDispose /> </Div>
+        ),
+      )
+      |> executeSideEffects
+      |> ignore;
+
+      expectInt(
+           ~label="The effect should've been run",
+           1,
+           effectCallCount^);
+
+      expectInt(~label="The dispose should not have been run yet",
+            0,
+            effectDisposeCallCount^);
+    }
+  ),
+  (
+    "Test 'OnMount' effect",
+    `Quick,
+    () => {
+      let effectCallCount = ref(0);
+      let effectDisposeCallCount = ref(0);
+      let onEffect = () => effectCallCount := effectCallCount^ + 1;
+      let onEffectDispose = () => effectDisposeCallCount := effectDisposeCallCount^ + 1;
+
+      let testState = render(<Components.EmptyComponentWithOnMountEffect onEffect onEffectDispose />)
+      |> executeSideEffects;
+
+      expectInt(
+           ~label="The effect should've been run",
+           1,
+           effectCallCount^);
+
+      expectInt(~label="The dispose should not have been run yet",
+            0,
+            effectDisposeCallCount^);
+
+      let testState =
+      testState
+      |> update(<Components.EmptyComponentWithOnMountEffect onEffect onEffectDispose />)
+      |> executeSideEffects;
+
+      expectInt(
+           ~label="The effect should not have been run again",
+           1,
+           effectCallCount^);
+
+      expectInt(~label="The effect dispose callback should not have been run yet",
+            0,
+            effectDisposeCallCount^);
+
+      testState
+      |> update(<Components.EmptyComponent />)
+      |> executeSideEffects
+      |> ignore;
+
+      expectInt(
+           ~label="The effect should not have been run again",
+           1,
+           effectCallCount^
+         );
+
+      /* TODO: FIX ME */
+      /* expectInt(~label="The effect dispose callback should have been called since the component was un-mounted.", */
+      /*       1, */
+      /*       effectDisposeCallCount^); */
+    }
+  ),
+  (
+    "Test 'OnMount' effect in nested component",
+    `Quick,
+    () => {
+      let effectCallCount = ref(0);
+      let effectDisposeCallCount = ref(0);
+      let onEffect = () => effectCallCount := effectCallCount^ + 1;
+      let onEffectDispose = () => effectDisposeCallCount := effectDisposeCallCount^ + 1;
+
+      render(
+        Components.(
+          <Div> <EmptyComponentWithOnMountEffect onEffect onEffectDispose /> </Div>
+        ),
+      )
+      |> executeSideEffects
+      |> ignore;
+
+      expectInt(
+           ~label="The effect should've been run",
+           1,
+           effectCallCount^);
+
+      expectInt(~label="The dispose should not have been run yet",
+            0,
+            effectDisposeCallCount^);
     }
   ),
 ];

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -173,7 +173,7 @@ let core = [
              ],
            );
 
-      RemoteAction.act(~action=Components.ToggleClicks.Click, rAction);
+      RemoteAction.send(~action=Components.ToggleClicks.Click, rAction);
       let cell1 = text("cell1");
       let cell2 = text("cell2");
 
@@ -263,42 +263,11 @@ let core = [
          )
       |> ignore,
   ),
-  /*
-   (
-     "Test willReceiveProps on ChangeCounter text update",
-     `Quick,
-     () =>
-       /* TODO: This needs some love, we are testing state updates */
-       render(<Components.ChangeCounter label="default text" />)
-       |> expect(~label="It renders ChangeCounter component", [])
-       |> update(<Components.ChangeCounter label="default text" />)
-       |> expect(~label="It doesn't create any UpdateLog records", [])
-       |> update(<Components.ChangeCounter label="updated text" />)
-       |> expect(~label="It increments its local state on text change", [])
-       |> flushPendingUpdates
-       |> expect(
-            ~label=
-              "It flushes uncommited updates incrementing the counter by 10 on each update",
-            [],
-          )
-       |> flushPendingUpdates
-       |> expect(
-            ~label="It flushes updates, but there are no pending actions",
-            [],
-          )
-       |> flushPendingUpdates
-       |> expect(
-            ~label="It flushes updates, but there are no pending actions",
-            [],
-          )
-       |> ignore,
-   ),
-   */
   (
     "Test changing components",
     `Quick,
     () =>
-      render(<Components.ChangeCounter label="default text" />)
+      render(<Components.EmptyComponent />)
       |> executeSideEffects
       |> expect(
            ~label="It renders ChangeCounter component",
@@ -526,7 +495,7 @@ let core = [
     },
   ),
   (
-    "Test 'shouldUpdate' lifecycle phase",
+    "Test conditional updating by leveraging refs",
     `Quick,
     () => {
       let rAction = RemoteAction.create();

--- a/renderer-macos/lib/components/Button.re
+++ b/renderer-macos/lib/components/Button.re
@@ -5,38 +5,39 @@ type attr = [ Layout.style | `Color(Color.t) | `Background(Color.t)];
 
 type style = list(attr);
 
-let component = statelessNativeComponent("Button");
+let component = nativeComponent("Button");
 let make =
-    (~type_=?, ~bezel=?, ~title=?, ~style=[], ~callback=() => (), children) => {
-  ...component,
-  render: _ => {
-    make: () => {
-      let btn =
-        BriskButton.(make(~type_?, ~bezel?, ~title?, ~onClick=callback, ()));
-      {view: btn, layoutNode: makeLayoutNode(~style, btn)};
-    },
-    shouldReconfigureInstance: (~oldState as _, ~newState as _) => true,
-    updateInstance: (_self, {view} as node) => {
-      style
-      |> List.iter(attr =>
-           switch (attr) {
-           | `Color(_) => ()
-           | `Background(({r, g, b, a}: Color.t)) =>
-             BriskView.setBackgroundColor(view, r, g, b, a)
-           | `Border(({width, color}: Border.t)) =>
-             if (!isUndefined(width)) {
-               BriskView.setBorderWidth(view, width);
-             };
-             let {r, g, b, a}: Color.t = color;
-             BriskView.setBorderColor(view, r, g, b, a);
-           | #Layout.style => ()
-           }
-         );
-      node;
-    },
-    children,
-  },
-};
+    (~type_=?, ~bezel=?, ~title=?, ~style=[], ~callback=() => (), children) =>
+  component((_: Slots.empty) =>
+    {
+      make: () => {
+        let btn =
+          BriskButton.(
+            make(~type_?, ~bezel?, ~title?, ~onClick=callback, ())
+          );
+        {view: btn, layoutNode: makeLayoutNode(~style, btn)};
+      },
+      configureInstance: (~isFirstRender as _, {view} as node) => {
+        style
+        |> List.iter(attr =>
+             switch (attr) {
+             | `Color(_) => ()
+             | `Background(({r, g, b, a}: Color.t)) =>
+               BriskView.setBackgroundColor(view, r, g, b, a)
+             | `Border(({width, color}: Border.t)) =>
+               if (!isUndefined(width)) {
+                 BriskView.setBorderWidth(view, width);
+               };
+               let {r, g, b, a}: Color.t = color;
+               BriskView.setBorderColor(view, r, g, b, a);
+             | #Layout.style => ()
+             }
+           );
+        node;
+      },
+      children,
+    }
+  );
 
 let createElement =
     (~type_=?, ~bezel=?, ~style=[], ~title=?, ~callback=?, ~children, ()) =>

--- a/renderer-macos/lib/components/Button.re
+++ b/renderer-macos/lib/components/Button.re
@@ -8,7 +8,7 @@ type style = list(attr);
 let component = nativeComponent("Button");
 let make =
     (~type_=?, ~bezel=?, ~title=?, ~style=[], ~callback=() => (), children) =>
-  component((_: Slots.empty) =>
+  component((_: Hooks.empty) =>
     {
       make: () => {
         let btn =

--- a/renderer-macos/lib/components/Image.re
+++ b/renderer-macos/lib/components/Image.re
@@ -5,7 +5,7 @@ type attr = [ Layout.style];
 
 type style = list(attr);
 
-let component = statelessNativeComponent("Image");
+let component = nativeComponent("Image");
 
 let measure = (node, _, _, _, _) => {
   open LayoutSupport.LayoutTypes;
@@ -18,26 +18,25 @@ let measure = (node, _, _, _, _) => {
   {width, height};
 };
 
-let make = (~style=[], ~source, children) => {
-  ...component,
-  render: _ => {
-    make: () => {
-      let view = BriskImage.make(~source, ());
-      {view, layoutNode: makeLayoutNode(~measure, ~style, view)};
-    },
-    shouldReconfigureInstance: (~oldState as _, ~newState as _) => true,
-    updateInstance: (_self, {view: _} as node) => {
-      style
-      |> List.iter(attr =>
-           switch (attr) {
-           | #Layout.style => ()
-           }
-         );
-      node;
-    },
-    children,
-  },
-};
+let make = (~style=[], ~source, children) =>
+  component((_: Slots.empty) =>
+    {
+      make: () => {
+        let view = BriskImage.make(~source, ());
+        {view, layoutNode: makeLayoutNode(~measure, ~style, view)};
+      },
+      configureInstance: (~isFirstRender as _, {view: _} as node) => {
+        style
+        |> List.iter(attr =>
+             switch (attr) {
+             | #Layout.style => ()
+             }
+           );
+        node;
+      },
+      children,
+    }
+  );
 
 let createElement = (~style=[], ~source, ~children, ()) =>
   element(make(~style, ~source, listToElement(children)));

--- a/renderer-macos/lib/components/Image.re
+++ b/renderer-macos/lib/components/Image.re
@@ -19,7 +19,7 @@ let measure = (node, _, _, _, _) => {
 };
 
 let make = (~style=[], ~source, children) =>
-  component((_: Slots.empty) =>
+  component((_: Hooks.empty) =>
     {
       make: () => {
         let view = BriskImage.make(~source, ());

--- a/renderer-macos/lib/components/Text.re
+++ b/renderer-macos/lib/components/Text.re
@@ -15,7 +15,7 @@ type attr = [
 
 type style = list(attr);
 
-let component = statelessNativeComponent("Text");
+let component = nativeComponent("Text");
 
 let measure = (node, _, _, _, _) => {
   open LayoutSupport.LayoutTypes;
@@ -28,15 +28,14 @@ let measure = (node, _, _, _, _) => {
   {width, height};
 };
 
-let make = (~style=[], ~value, children) => {
-  ...component,
-  render: _ => {
-    make: () => {
-      let view = BriskTextView.make(value);
-      {view, layoutNode: makeLayoutNode(~measure, ~style, view)};
-    },
-    shouldReconfigureInstance: (~oldState as _, ~newState as _) => true,
-    updateInstance: (_self, {view} as node) => {
+let make = (~style=[], ~value, children) =>
+  component((_: Slots.empty) =>
+    {
+      make: () => {
+        let view = BriskTextView.make(value);
+        {view, layoutNode: makeLayoutNode(~measure, ~style, view)};
+      },
+      configureInstance: (~isFirstRender as _, {view} as node) => {
       style
       |> List.iter(attr =>
            switch (attr) {
@@ -81,9 +80,9 @@ let make = (~style=[], ~value, children) => {
          );
       node;
     },
-    children,
-  },
-};
+      children,
+    }
+  );
 
 let createElement = (~style=[], ~value, ~children, ()) =>
   element(make(~style, ~value, listToElement(children)));

--- a/renderer-macos/lib/components/Text.re
+++ b/renderer-macos/lib/components/Text.re
@@ -29,7 +29,7 @@ let measure = (node, _, _, _, _) => {
 };
 
 let make = (~style=[], ~value, children) =>
-  component((_: Slots.empty) =>
+  component((_: Hooks.empty) =>
     {
       make: () => {
         let view = BriskTextView.make(value);

--- a/renderer-macos/lib/components/View.re
+++ b/renderer-macos/lib/components/View.re
@@ -8,7 +8,7 @@ type style = list(attr);
 let component = nativeComponent("View");
 
 let make = (~style: style=[], children) =>
-  component((_: Slots.empty) =>
+  component((_: Hooks.empty) =>
     {
       make: () => {
         let view = NSView.make();

--- a/renderer-macos/lib/components/View.re
+++ b/renderer-macos/lib/components/View.re
@@ -11,7 +11,7 @@ let make = (~style: style=[], children) =>
   component((_: Hooks.empty) =>
     {
       make: () => {
-        let view = NSView.make();
+        let view = BriskView.make();
         {view, layoutNode: makeLayoutNode(~style, view)};
       },
       configureInstance: (~isFirstRender as _, {view} as node) => {

--- a/renderer-macos/lib/components/View.re
+++ b/renderer-macos/lib/components/View.re
@@ -5,35 +5,35 @@ type attr = [ Layout.style | `Background(Color.t)];
 
 type style = list(attr);
 
-let component = statelessNativeComponent("View");
-let make = (~style: style=[], children) => {
-  ...component,
-  render: _ => {
-    make: () => {
-      let view = BriskView.make();
-      {view, layoutNode: makeLayoutNode(~style, view)};
-    },
-    shouldReconfigureInstance: (~oldState as _, ~newState as _) => true,
-    updateInstance: (_self, {view} as node) => {
-      style
-      |> List.iter(attr =>
-           switch (attr) {
-           | `Background(({r, g, b, a}: Color.t)) =>
-             BriskView.setBackgroundColor(view, r, g, b, a)
-           | `Border(({width, color}: Border.t)) =>
-             if (!isUndefined(width)) {
-               BriskView.setBorderWidth(view, width);
-             };
-             let {r, g, b, a}: Color.t = color;
-             BriskView.setBorderColor(view, r, g, b, a);
-           | #Layout.style => ()
-           }
-         );
-      node;
-    },
-    children,
-  },
-};
+let component = nativeComponent("View");
+
+let make = (~style: style=[], children) =>
+  component((_: Slots.empty) =>
+    {
+      make: () => {
+        let view = NSView.make();
+        {view, layoutNode: makeLayoutNode(~style, view)};
+      },
+      configureInstance: (~isFirstRender as _, {view} as node) => {
+        style
+        |> List.iter(attr =>
+             switch (attr) {
+             | `Background(({r, g, b, a}: Color.t)) =>
+               BriskView.setBackgroundColor(view, r, g, b, a)
+             | `Border(({width, color}: Border.t)) =>
+               if (!isUndefined(width)) {
+                 BriskView.setBorderWidth(view, width);
+               };
+               let {r, g, b, a}: Color.t = color;
+               BriskView.setBorderColor(view, r, g, b, a);
+             | #Layout.style => ()
+             }
+           );
+        node;
+      },
+      children,
+    }
+  );
 
 let createElement = (~style=[], ~children, ()) =>
   element(make(~style, listToElement(children)));

--- a/tester-macos/bin/app.re
+++ b/tester-macos/bin/app.re
@@ -7,95 +7,90 @@ module BriskMenu = Menu;
 module Component = {
   [@noalloc] external lwt_start: unit => unit = "ml_lwt_iter";
 
-  let otherComponent = Brisk.reducerComponent("Other");
-  let createElement = (~children as _, ()) => {
-    ...otherComponent,
-    initialState: _ => None,
-    reducer: (x, _) => Brisk.Update(x),
-    render: ({state, reduce}) =>
-      switch (state) {
-      | Some(code) =>
+let component = React.component("Other");
+let createElement = (~children as _, ()) =>
+  component(slots => {
+    let (state, setState, _slots: React.Slots.empty) =
+      React.Hooks.useState(None, slots);
+
+    switch (state) {
+    | Some(code) =>
+      <View
+        style=[
+          width(100.),
+          height(100.),
+          background(Color.rgb(0, 255, 0)),
+          border(~width=1., ~color=Color.rgb(0, 0, 255), ()),
+        ]>
+        <Button
+          style=[width(100.), height(100.)]
+          title={string_of_int(code)}
+          callback={() => setState(None)}
+        />
+        <Button
+          style=[width(100.), height(100.)]
+          title="Cell two"
+          callback={() => setState(None)}
+        />
+      </View>
+    | None =>
+      <View
+        style=[
+          position(~top=0., ~left=0., ~right=0., ~bottom=0., `Absolute),
+          width(600.),
+          height(400.),
+          background(Color.hex("#f7f8f9")),
+        ]>
+        <Text
+          style=[
+            font(~size=24., ~weight=`Medium, ()),
+            kern(0.5),
+            align(`Center),
+            color(Color.hex("#ffffff")),
+            background(Color.hex("#263ac5")),
+            padding(10.),
+          ]
+          value="Welcome to Brisk"
+        />
         <View
           style=[
-            width(100.),
-            height(100.),
-            background(Color.rgb(0, 255, 0)),
-            border(~width=1., ~color=Color.rgb(0, 0, 255), ()),
+            justifyContent(`Center),
+            alignContent(`Center),
+            background(Color.hex("#eeeeee")),
           ]>
-          <Button
-            style=[width(100.), height(100.)]
-            title={string_of_int(code)}
-            callback={reduce(() => None)}
+          <Image
+            style=[margin4(~top=10., ()), alignSelf(`Center)]
+            source={`Bundle("reason")}
           />
-          <Button
-            style=[width(100.), height(100.)]
-            title="Cell two"
-            callback={reduce(() => None)}
-          />
-        </View>
-      | None =>
-        <View
-          style=[
-            position(~top=0., ~left=0., ~right=0., ~bottom=0., `Absolute),
-            width(600.),
-            height(400.),
-            background(Color.hex("#f7f8f9")),
-          ]>
           <Text
             style=[
-              font(~size=24., ~weight=`Medium, ()),
-              kern(0.5),
+              font(~size=18., ()),
               align(`Center),
+              alignSelf(`Center),
+              width(200.),
+              cornerRadius(10.),
               color(Color.hex("#ffffff")),
-              background(Color.hex("#263ac5")),
-              padding(10.),
+              background(Color.hexa("#263ac5", 0.9)),
+              margin(20.),
+              padding2(~h=10., ~v=10., ()),
             ]
-            value="Welcome to Brisk"
-          />
-          <View
-            style=[
-              justifyContent(`Center),
-              alignContent(`Center),
-              background(Color.hex("#eeeeee")),
-            ]>
-            <Image
-              style=[margin4(~top=10., ()), alignSelf(`Center)]
-              source={`Bundle("reason")}
-            />
-            <Text
-              style=[
-                font(~size=18., ()),
-                align(`Center),
-                alignSelf(`Center),
-                width(200.),
-                cornerRadius(10.),
-                color(Color.hex("#ffffff")),
-                background(Color.hexa("#263ac5", 0.9)),
-                margin(20.),
-                padding2(~h=10., ~v=10., ()),
-              ]
-              value="Text bubble"
-            />
-          </View>
-          <Button
-            style=[width(400.), height(60.)]
-            title="Youre gonna have to wait a bit"
-            callback={
-                       let callback = reduce(code => code);
-                       (
-                         () => {
-                           lwt_start();
-                           ignore(
-                             Lwt_unix.sleep(1.)
-                             >>= (_ => Lwt.return(callback(Some(100)))),
-                           );
-                         }
-                       );
-                     }
+            value="Text bubble"
           />
         </View>
-      },
-  };
+        <Button
+          style=[width(400.), height(60.)]
+          title="Youre gonna have to wait a bit"
+          callback={() => {
+            lwt_start();
+            ignore(
+              Lwt_unix.sleep(1.)
+              >>= (_ => Lwt.return(setState(Some(100)))),
+            );
+          }}
+        />
+      </View>
+    };
+  });
 };
 
 let lwt_iter = () => {

--- a/tester-macos/bin/app.re
+++ b/tester-macos/bin/app.re
@@ -7,11 +7,11 @@ module BriskMenu = Menu;
 module Component = {
   [@noalloc] external lwt_start: unit => unit = "ml_lwt_iter";
 
-let component = React.component("Other");
+let component = Brisk.component("Other");
 let createElement = (~children as _, ()) =>
   component(slots => {
-    let (state, setState, _slots: React.Hooks.empty) =
-      React.Hooks.useState(None, slots);
+    let (state, setState, _slots: Brisk.Hooks.empty) =
+      Brisk.Hooks.state(None, slots);
 
     switch (state) {
     | Some(code) =>

--- a/tester-macos/bin/app.re
+++ b/tester-macos/bin/app.re
@@ -10,7 +10,7 @@ module Component = {
 let component = React.component("Other");
 let createElement = (~children as _, ()) =>
   component(slots => {
-    let (state, setState, _slots: React.Slots.empty) =
+    let (state, setState, _slots: React.Hooks.empty) =
       React.Hooks.useState(None, slots);
 
     switch (state) {


### PR DESCRIPTION
This PR introduces basic support for [a React-Hook like](https://reactjs.org/docs/hooks-overview.html) API. The only supported hooks are `useState` and `useReducer`. Implementing `useEffect` will probably require some architectural overhaul to the current naive Slots approach. Also, there's **a lot**
of mutation everywhere now. It'd be great to minimise this in the next version.

### Temporary component API

If you look at the tests the component looks like this:

```
let component = component(debugName);
let make = (~prop, children) => component(slots => { ... });
let createElement = ...
```

This API is temporary because it doesn't require a PPX for JSX. The planned API is:

```
let componentName = component((slots, ~prop, ~prop2, ()) => { ... })
```