### PR TITLE
[Test case] State update in subtree not being picked up

### DIFF
--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -174,7 +174,7 @@ let core = [
              ],
            );
 
-      RemoteAction.act(~action=Components.ToggleClicks.Click, rAction);
+      RemoteAction.send(~action=Components.ToggleClicks.Click, rAction);
       /* TODO: Bring back! */
       /* let cell1 = text("cell1"); */
       /* let cell2 = text("cell2"); */

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -175,23 +175,24 @@ let core = [
            );
 
       RemoteAction.send(~action=Components.ToggleClicks.Click, rAction);
-      /* TODO: Bring back! */
-      /* let cell1 = text("cell1"); */
-      /* let cell2 = text("cell2"); */
+      let cell1 = text("cell1");
+      let cell2 = text("cell2");
 
       testState
       |> flushPendingUpdates
       |> executeSideEffects
+      /* BUG:
+       * This expectation fails when there is a top-level `<Div>` element
+       */
       |> expect(
            ~label="It replaces text(well) with text(cell1) and text(cell2)",
            [
              Implementation.BeginChanges,
-             /* TODO: Fix - we should see these updates occur! */
-             /* UnmountChild(div, well), */
-             /* ChangeText("cell1", "cell1"), */
-             /* MountChild(div, cell1, 0), */
-             /* ChangeText("cell2", "cell2"), */
-             /* MountChild(div, cell2, 1), */
+             UnmountChild(div, well),
+             ChangeText("cell1", "cell1"),
+             MountChild(div, cell1, 0),
+             ChangeText("cell2", "cell2"),
+             MountChild(div, cell2, 1),
              CommitChanges,
            ],
          )

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -152,6 +152,53 @@ let core = [
       |> ignore,
   ),
   (
+    "Test subtree replace elements (not at top-level)",
+    `Quick,
+    () => {
+      let rAction = RemoteAction.create();
+
+      let well = text("well");
+
+      let testState =
+        render(Components.(<Div><ToggleClicks rAction /></Div>))
+        |> executeSideEffects
+        |> expect(
+             ~label="It constructs the initial tree",
+             [
+               Implementation.BeginChanges,
+               ChangeText("well", "well"),
+               MountChild(div, well, 0),
+               MountChild(div, div, 0),
+               MountChild(root, div, 0),
+               CommitChanges,
+             ],
+           );
+
+      RemoteAction.act(~action=Components.ToggleClicks.Click, rAction);
+      /* TODO: Bring back! */
+      /* let cell1 = text("cell1"); */
+      /* let cell2 = text("cell2"); */
+
+      testState
+      |> flushPendingUpdates
+      |> executeSideEffects
+      |> expect(
+           ~label="It replaces text(well) with text(cell1) and text(cell2)",
+           [
+             Implementation.BeginChanges,
+             /* TODO: Fix - we should see these updates occur! */
+             /* UnmountChild(div, well), */
+             /* ChangeText("cell1", "cell1"), */
+             /* MountChild(div, cell1, 0), */
+             /* ChangeText("cell2", "cell2"), */
+             /* MountChild(div, cell2, 1), */
+             CommitChanges,
+           ],
+         )
+      |> ignore;
+    },
+  ),
+  (
     "Test subtree replace elements",
     `Quick,
     () => {


### PR DESCRIPTION
__Issue:__ Nested components in the tree don't seem to 'bubble up' their state changes into `flushPendingUpdates`. This means that state changes work fine when `useState` is the top-level element that we call `flushPendingUpdates` on, but if it is lower in the tree, the updates don't get picked up.

This is possibly a misunderstanding on my end of the API, but it'd be helpful to see how to handle this case for revery https://github.com/revery-ui/revery/pull/207