### PR TITLE
Hooks: Test cases for Effects

### DIFF
--- a/core/test/Assert.re
+++ b/core/test/Assert.re
@@ -146,6 +146,10 @@ let expect = (~label=?, expected, testState) => {
   reset(testState);
 };
 
+let expectInt = (~label, expected, actual) => {
+    Alcotest.(check(int))(label, expected, actual);
+};
+
 let act = (~action, rAction, testState) => {
   RemoteAction.send(rAction, ~action);
   testState;

--- a/core/test/Components.re
+++ b/core/test/Components.re
@@ -204,3 +204,29 @@ module EmptyComponent = {
   let createElement = (~key=?, ~children as _children, ()) =>
     element(~key?, make());
 };
+
+module EmptyComponentWithAlwaysEffect = {
+  let component = component("Box");
+  let make = (~onEffect, ~onEffectDispose, _children) => component((slots) => {
+      let _slots: Hooks.empty = Hooks.effect(Always, () => {
+        onEffect(); 
+        Some(onEffectDispose);
+      }, slots);
+      listToElement([])
+  });
+  let createElement = (~key=?, ~children as _children, ~onEffect, ~onEffectDispose, ()) =>
+    element(~key?, make(~onEffect, ~onEffectDispose, _children));
+};
+
+/* module EmptyComponentWithAlwaysEffect = { */
+/*   let component = component("Box"); */
+/*   let make = (~onEffect, ~onEffectDispose, _children) => component((slots: Hooks.empty) => { */
+/*       let _slots: Hooks.empty = Hooks.effect(Always, () => { */
+/*         onEffect(); */ 
+/*         Some(onEffectDispose); */
+/*       }, slots); */
+/*       listToElement([]) */
+/*   }); */
+/*   let createElement = (~key=?, ~children as _children, ()) => */
+/*     element(~key?, make()); */
+/* }; */

--- a/core/test/Components.re
+++ b/core/test/Components.re
@@ -218,15 +218,15 @@ module EmptyComponentWithAlwaysEffect = {
     element(~key?, make(~onEffect, ~onEffectDispose, _children));
 };
 
-/* module EmptyComponentWithAlwaysEffect = { */
-/*   let component = component("Box"); */
-/*   let make = (~onEffect, ~onEffectDispose, _children) => component((slots: Hooks.empty) => { */
-/*       let _slots: Hooks.empty = Hooks.effect(Always, () => { */
-/*         onEffect(); */ 
-/*         Some(onEffectDispose); */
-/*       }, slots); */
-/*       listToElement([]) */
-/*   }); */
-/*   let createElement = (~key=?, ~children as _children, ()) => */
-/*     element(~key?, make()); */
-/* }; */
+module EmptyComponentWithOnMountEffect = {
+  let component = component("Box");
+  let make = (~onEffect, ~onEffectDispose, _children) => component((slots) => {
+      let _slots: Hooks.empty = Hooks.effect(OnMount, () => {
+        onEffect(); 
+        Some(onEffectDispose);
+      }, slots);
+      listToElement([])
+  });
+  let createElement = (~key=?, ~children as _children, ~onEffect, ~onEffectDispose, ()) =>
+    element(~key?, make(~onEffect, ~onEffectDispose, _children));
+};

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -689,6 +689,44 @@ let core = [
       |> ignore;
     },
   ),
+  (
+    "Test 'always' effect",
+    `Quick,
+    () => {
+      let effectCallCount = ref(0);
+      let effectDisposeCallCount = ref(0);
+      let onEffect = () => effectCallCount := effectCallCount^ + 1;
+      let onEffectDispose = () => effectDisposeCallCount := effectDisposeCallCount^ + 1;
+
+      let testState = render(<Components.EmptyComponentWithAlwaysEffect onEffect onEffectDispose />)
+      |> executeSideEffects;
+
+      expectInt(
+           ~label="The effect should've been run",
+           effectCallCount^,
+           1
+         );
+
+      expectInt(~label="The dispose should not have been run yet",
+            effectDisposeCallCount^,
+            0);
+
+      testState
+      |> update(<Components.EmptyComponentWithAlwaysEffect onEffect onEffectDispose />)
+      |> executeSideEffects
+      |> ignore;
+
+      expectInt(
+           ~label="The effect should've been run again",
+           effectCallCount^,
+           2
+         );
+
+      expectInt(~label="The effect dispose callback should have been run",
+            effectDisposeCallCount^,
+            1);
+    }
+  ),
 ];
 
 /** Annoying dune progress */

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -799,11 +799,13 @@ let core = [
            effectCallCount^
          );
 
-      /* TODO: FIX ME */
-      /* expectInt(~label="The effect dispose callback should have been called since the component was un-mounted.", */
-      /*       1, */
-      /*       effectDisposeCallCount^); */
-    }
+      expectInt(
+        ~label=
+          "The effect dispose callback should have been called since the component was un-mounted.",
+        1,
+        effectDisposeCallCount^,
+      );
+    },
   ),
   (
     "Test 'OnMount' effect in nested component",

--- a/core/test/Test.re
+++ b/core/test/Test.re
@@ -690,11 +690,12 @@ let core = [
     },
   ),
   (
-    "Test 'always' effect",
+    "Test 'Always' effect",
     `Quick,
     () => {
       let effectCallCount = ref(0);
       let effectDisposeCallCount = ref(0);
+
       let onEffect = () => effectCallCount := effectCallCount^ + 1;
       let onEffectDispose = () => effectDisposeCallCount := effectDisposeCallCount^ + 1;
 
@@ -703,13 +704,12 @@ let core = [
 
       expectInt(
            ~label="The effect should've been run",
-           effectCallCount^,
-           1
-         );
+           1,
+           effectCallCount^);
 
       expectInt(~label="The dispose should not have been run yet",
-            effectDisposeCallCount^,
-            0);
+            0,
+            effectDisposeCallCount^);
 
       testState
       |> update(<Components.EmptyComponentWithAlwaysEffect onEffect onEffectDispose />)
@@ -718,13 +718,118 @@ let core = [
 
       expectInt(
            ~label="The effect should've been run again",
-           effectCallCount^,
-           2
-         );
+           2,
+           effectCallCount^);
 
       expectInt(~label="The effect dispose callback should have been run",
-            effectDisposeCallCount^,
-            1);
+            1,
+            effectDisposeCallCount^);
+    }
+  ),
+  (
+    "Test 'Always' effect in a nested component",
+    `Quick,
+    () => {
+      let effectCallCount = ref(0);
+      let effectDisposeCallCount = ref(0);
+      let onEffect = () => effectCallCount := effectCallCount^ + 1;
+      let onEffectDispose = () => effectDisposeCallCount := effectDisposeCallCount^ + 1;
+
+      render(
+        Components.(
+          <Div> <EmptyComponentWithAlwaysEffect onEffect onEffectDispose /> </Div>
+        ),
+      )
+      |> executeSideEffects
+      |> ignore;
+
+      expectInt(
+           ~label="The effect should've been run",
+           1,
+           effectCallCount^);
+
+      expectInt(~label="The dispose should not have been run yet",
+            0,
+            effectDisposeCallCount^);
+    }
+  ),
+  (
+    "Test 'OnMount' effect",
+    `Quick,
+    () => {
+      let effectCallCount = ref(0);
+      let effectDisposeCallCount = ref(0);
+      let onEffect = () => effectCallCount := effectCallCount^ + 1;
+      let onEffectDispose = () => effectDisposeCallCount := effectDisposeCallCount^ + 1;
+
+      let testState = render(<Components.EmptyComponentWithOnMountEffect onEffect onEffectDispose />)
+      |> executeSideEffects;
+
+      expectInt(
+           ~label="The effect should've been run",
+           1,
+           effectCallCount^);
+
+      expectInt(~label="The dispose should not have been run yet",
+            0,
+            effectDisposeCallCount^);
+
+      let testState =
+      testState
+      |> update(<Components.EmptyComponentWithOnMountEffect onEffect onEffectDispose />)
+      |> executeSideEffects;
+
+      expectInt(
+           ~label="The effect should not have been run again",
+           1,
+           effectCallCount^);
+
+      expectInt(~label="The effect dispose callback should not have been run yet",
+            0,
+            effectDisposeCallCount^);
+
+      testState
+      |> update(<Components.EmptyComponent />)
+      |> executeSideEffects
+      |> ignore;
+
+      expectInt(
+           ~label="The effect should not have been run again",
+           1,
+           effectCallCount^
+         );
+
+      /* TODO: FIX ME */
+      /* expectInt(~label="The effect dispose callback should have been called since the component was un-mounted.", */
+      /*       1, */
+      /*       effectDisposeCallCount^); */
+    }
+  ),
+  (
+    "Test 'OnMount' effect in nested component",
+    `Quick,
+    () => {
+      let effectCallCount = ref(0);
+      let effectDisposeCallCount = ref(0);
+      let onEffect = () => effectCallCount := effectCallCount^ + 1;
+      let onEffectDispose = () => effectDisposeCallCount := effectDisposeCallCount^ + 1;
+
+      render(
+        Components.(
+          <Div> <EmptyComponentWithOnMountEffect onEffect onEffectDispose /> </Div>
+        ),
+      )
+      |> executeSideEffects
+      |> ignore;
+
+      expectInt(
+           ~label="The effect should've been run",
+           1,
+           effectCallCount^);
+
+      expectInt(~label="The dispose should not have been run yet",
+            0,
+            effectDisposeCallCount^);
     }
   ),
 ];


### PR DESCRIPTION
This adds a couple of test cases for effects around `Always` and `OnMount` conditions.

I was trying to reproduce the issue I'm hitting with the `OnMount` hook in `revery`. These tests are green except for a case for calling the 'dispose' callback when the condition is `OnMount`.