### PR TITLE
Button component improvements

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -15,12 +15,12 @@
   },
   "dependencies": {
     "@esy-ocaml/reason": ">=3.4.0",
-    "brisk-reconciler": "*",
     "@brisk/macos": "*",
-    "@brisk/tester-macos": "*"
+    "@brisk/tester-macos": "*",
+    "brisk-reconciler": "*"
   },
   "devDependencies": {
-    "@opam/merlin": "^3.2.2",
+    "@opam/merlin-lsp": "*",
     "ocaml": "~4.7.1000"
   },
   "resolutions": {
@@ -28,6 +28,7 @@
     "@brisk/macos": "link-dev:./renderer-macos",
     "@brisk/tester-macos": "link-dev:./tester-macos",
     "@opam/osx-cf": "mirage/ocaml-osx-cf:opam#0c63247",
+    "@opam/merlin-lsp": "ocaml/merlin:merlin-lsp.opam#3e34bb5",
     "brisk-reconciler": "briskml/brisk-reconciler#fa605f1"
   }
 }

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "68e6e745c07aeda1c36312a697a71d71",
+  "checksum": "0d49a370688fd7b288a396e324d873da",
   "root": "brisk@link-dev:./esy.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#d488cd9321cd5036bd36ec96744ce78c5d45fc49@d41d8cd9": {
@@ -123,7 +123,8 @@
         "@brisk/macos@link-dev:renderer-macos"
       ],
       "devDependencies": [
-        "ocaml@4.7.1003@d41d8cd9", "@opam/merlin@opam:3.2.2@829ee6dd"
+        "ocaml@4.7.1003@d41d8cd9",
+        "@opam/merlin-lsp@github:ocaml/merlin:merlin-lsp.opam#3e34bb5@d41d8cd9"
       ]
     },
     "@opam/yojson@opam:1.5.0@890db858": {
@@ -497,6 +498,34 @@
         "@opam/base@opam:v0.11.1@0e54024e"
       ]
     },
+    "@opam/ppxfind@opam:1.2@0443ec6f": {
+      "id": "@opam/ppxfind@opam:1.2@0443ec6f",
+      "name": "@opam/ppxfind",
+      "version": "opam:1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/3c/3c6f81800bb816e190a64f9898481f82#md5:3c6f81800bb816e190a64f9898481f82",
+          "archive:https://github.com/diml/ppxfind/releases/download/1.2/ppxfind-1.2.tbz#md5:3c6f81800bb816e190a64f9898481f82"
+        ],
+        "opam": {
+          "name": "ppxfind",
+          "version": "1.2",
+          "path": "esy.lock/opam/ppxfind.1.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1003@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocaml-migrate-parsetree@opam:1.2.0@5b3aa0d3",
+        "@opam/jbuilder@opam:transition@58bdfe0a",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1003@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocaml-migrate-parsetree@opam:1.2.0@5b3aa0d3"
+      ]
+    },
     "@opam/ppx_tools_versioned@opam:5.2.1@95275a75": {
       "id": "@opam/ppx_tools_versioned@opam:5.2.1@95275a75",
       "name": "@opam/ppx_tools_versioned",
@@ -523,6 +552,31 @@
       "devDependencies": [
         "ocaml@4.7.1003@d41d8cd9",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@5b3aa0d3"
+      ]
+    },
+    "@opam/ppx_tools@opam:5.1+4.06.0@a9357225": {
+      "id": "@opam/ppx_tools@opam:5.1+4.06.0@a9357225",
+      "name": "@opam/ppx_tools",
+      "version": "opam:5.1+4.06.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/6b/6ba2e9690b1f579ba562b86022d1c308#md5:6ba2e9690b1f579ba562b86022d1c308",
+          "archive:https://github.com/ocaml-ppx/ppx_tools/archive/5.1+4.06.0.tar.gz#md5:6ba2e9690b1f579ba562b86022d1c308"
+        ],
+        "opam": {
+          "name": "ppx_tools",
+          "version": "5.1+4.06.0",
+          "path": "esy.lock/opam/ppx_tools.5.1+4.06.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1003@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1003@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762"
       ]
     },
     "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527": {
@@ -585,6 +639,76 @@
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@5b3aa0d3",
         "@opam/fieldslib@opam:v0.11.0@c86ba0e6",
         "@opam/base@opam:v0.11.1@0e54024e"
+      ]
+    },
+    "@opam/ppx_deriving_yojson@opam:3.3@9029495a": {
+      "id": "@opam/ppx_deriving_yojson@opam:3.3@9029495a",
+      "name": "@opam/ppx_deriving_yojson",
+      "version": "opam:3.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha512/e0/e04ee424d89423ca891e018b3ea6e3f5f1e3714bd1ec1b07187143da1a646e51d068d1c09bc794e25b5b5be00ccb517212f62853ec66c17969a9795ba88fae6a#sha512:e04ee424d89423ca891e018b3ea6e3f5f1e3714bd1ec1b07187143da1a646e51d068d1c09bc794e25b5b5be00ccb517212f62853ec66c17969a9795ba88fae6a",
+          "archive:https://github.com/ocaml-ppx/ppx_deriving_yojson/archive/v3.3.tar.gz#sha512:e04ee424d89423ca891e018b3ea6e3f5f1e3714bd1ec1b07187143da1a646e51d068d1c09bc794e25b5b5be00ccb517212f62853ec66c17969a9795ba88fae6a"
+        ],
+        "opam": {
+          "name": "ppx_deriving_yojson",
+          "version": "3.3",
+          "path": "esy.lock/opam/ppx_deriving_yojson.3.3"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1003@d41d8cd9", "@opam/yojson@opam:1.5.0@890db858",
+        "@opam/result@opam:1.3@bee8bf2e", "@opam/ppxfind@opam:1.2@0443ec6f",
+        "@opam/ppx_tools@opam:5.1+4.06.0@a9357225",
+        "@opam/ppx_deriving@opam:4.2.1@7927b93a",
+        "@opam/dune@opam:1.6.3@a7d7baed", "@opam/cppo@opam:1.6.5@bec3dbd9",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1003@d41d8cd9", "@opam/yojson@opam:1.5.0@890db858",
+        "@opam/result@opam:1.3@bee8bf2e",
+        "@opam/ppx_deriving@opam:4.2.1@7927b93a"
+      ]
+    },
+    "@opam/ppx_deriving@opam:4.2.1@7927b93a": {
+      "id": "@opam/ppx_deriving@opam:4.2.1@7927b93a",
+      "name": "@opam/ppx_deriving",
+      "version": "opam:4.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/21/2195fccf2a527c3ff9ec5b4e36e2f0a8#md5:2195fccf2a527c3ff9ec5b4e36e2f0a8",
+          "archive:https://github.com/ocaml-ppx/ppx_deriving/archive/v4.2.1.tar.gz#md5:2195fccf2a527c3ff9ec5b4e36e2f0a8"
+        ],
+        "opam": {
+          "name": "ppx_deriving",
+          "version": "4.2.1",
+          "path": "esy.lock/opam/ppx_deriving.4.2.1"
+        }
+      },
+      "overrides": [
+        {
+          "opamoverride":
+            "esy.lock/overrides/opam__s__ppx__deriving_opam__c__4.2.1_opam_override"
+        }
+      ],
+      "dependencies": [
+        "ocaml@4.7.1003@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
+        "@opam/ppx_tools@opam:5.1+4.06.0@a9357225",
+        "@opam/ppx_derivers@opam:1.0@78655ff8",
+        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlbuild@opam:0.12.0@6c616094",
+        "@opam/ocaml-migrate-parsetree@opam:1.2.0@5b3aa0d3",
+        "@opam/cppo_ocamlbuild@opam:1.6.0@7c1eb503",
+        "@opam/cppo@opam:1.6.5@bec3dbd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1003@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
+        "@opam/ppx_tools@opam:5.1+4.06.0@a9357225",
+        "@opam/ppx_derivers@opam:1.0@78655ff8",
+        "@opam/ocaml-migrate-parsetree@opam:1.2.0@5b3aa0d3"
       ]
     },
     "@opam/ppx_derivers@opam:1.0@78655ff8": {
@@ -794,6 +918,30 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1003@d41d8cd9" ]
+    },
+    "@opam/merlin-lsp@github:ocaml/merlin:merlin-lsp.opam#3e34bb5@d41d8cd9": {
+      "id":
+        "@opam/merlin-lsp@github:ocaml/merlin:merlin-lsp.opam#3e34bb5@d41d8cd9",
+      "name": "@opam/merlin-lsp",
+      "version": "github:ocaml/merlin:merlin-lsp.opam#3e34bb5",
+      "source": {
+        "type": "install",
+        "source": [ "github:ocaml/merlin:merlin-lsp.opam#3e34bb5" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/yojson@opam:1.5.0@890db858",
+        "@opam/stringext@opam:1.5.0@fc7e81d0",
+        "@opam/ppx_deriving_yojson@opam:3.3@9029495a",
+        "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/dune@opam:1.6.3@a7d7baed", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "@opam/yojson@opam:1.5.0@890db858",
+        "@opam/stringext@opam:1.5.0@fc7e81d0",
+        "@opam/ppx_deriving_yojson@opam:3.3@9029495a",
+        "@opam/ocamlfind@opam:1.8.0@96572762"
+      ]
     },
     "@opam/merlin-extend@opam:0.3@e1fc0d08": {
       "id": "@opam/merlin-extend@opam:0.3@e1fc0d08",
@@ -1316,6 +1464,35 @@
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
+    "@opam/cppo_ocamlbuild@opam:1.6.0@7c1eb503": {
+      "id": "@opam/cppo_ocamlbuild@opam:1.6.0@7c1eb503",
+      "name": "@opam/cppo_ocamlbuild",
+      "version": "opam:1.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ae/aee411b3546bc5d198c71ae9185cade4#md5:aee411b3546bc5d198c71ae9185cade4",
+          "archive:https://github.com/mjambon/cppo/archive/v1.6.0.tar.gz#md5:aee411b3546bc5d198c71ae9185cade4"
+        ],
+        "opam": {
+          "name": "cppo_ocamlbuild",
+          "version": "1.6.0",
+          "path": "esy.lock/opam/cppo_ocamlbuild.1.6.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1003@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlbuild@opam:0.12.0@6c616094",
+        "@opam/jbuilder@opam:transition@58bdfe0a",
+        "@opam/cppo@opam:1.6.5@bec3dbd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.7.1003@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@96572762",
+        "@opam/ocamlbuild@opam:0.12.0@6c616094",
+        "@opam/cppo@opam:1.6.5@bec3dbd9"
+      ]
+    },
     "@opam/cppo@opam:1.6.5@bec3dbd9": {
       "id": "@opam/cppo@opam:1.6.5@bec3dbd9",
       "name": "@opam/cppo",
@@ -1586,17 +1763,17 @@
         "ocaml@4.7.1003@d41d8cd9", "@opam/sexplib0@opam:v0.11.0@9df6bcd1",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/lwt@opam:4.1.0@111fc2bf", "@opam/dune@opam:1.6.3@a7d7baed",
-        "@opam/cohttp@opam:1.2.0@2ce8eb58",
+        "@opam/cohttp@opam:1.2.0@e5361bab",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1003@d41d8cd9", "@opam/sexplib0@opam:v0.11.0@9df6bcd1",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
-        "@opam/lwt@opam:4.1.0@111fc2bf", "@opam/cohttp@opam:1.2.0@2ce8eb58"
+        "@opam/lwt@opam:4.1.0@111fc2bf", "@opam/cohttp@opam:1.2.0@e5361bab"
       ]
     },
-    "@opam/cohttp@opam:1.2.0@2ce8eb58": {
-      "id": "@opam/cohttp@opam:1.2.0@2ce8eb58",
+    "@opam/cohttp@opam:1.2.0@e5361bab": {
+      "id": "@opam/cohttp@opam:1.2.0@e5361bab",
       "name": "@opam/cohttp",
       "version": "opam:1.2.0",
       "source": {

--- a/esy.lock/opam/cohttp.1.2.0/opam
+++ b/esy.lock/opam/cohttp.1.2.0/opam
@@ -50,7 +50,7 @@ depends: [
   "ppx_fields_conv" {>= "v0.9.0" & < "v0.12"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.12"}
   "stringext"
-  "base64" {>= "2.0.0"}
+  "base64" {>= "2.0.0" & < "3.0.0"}
   "fmt" {with-test}
   "jsonm" {build}
   "alcotest" {with-test}

--- a/esy.lock/opam/cppo_ocamlbuild.1.6.0/opam
+++ b/esy.lock/opam/cppo_ocamlbuild.1.6.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "http://mjambon.com/cppo.html"
+dev-repo: "git+https://github.com/mjambon/cppo.git"
+bug-reports: "https://github.com/mjambon/cppo/issues"
+license: "BSD-3-Clause"
+
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"
+  "jbuilder" {build & >= "1.0+beta10"}
+  "ocamlbuild"
+  "ocamlfind"
+  "cppo" {>= "1.6.0"}
+]
+synopsis: "ocamlbuild support for cppo, OCaml-friendly source preprocessor"
+url {
+  src: "https://github.com/mjambon/cppo/archive/v1.6.0.tar.gz"
+  checksum: "md5=aee411b3546bc5d198c71ae9185cade4"
+}

--- a/esy.lock/opam/ppx_deriving.4.2.1/opam
+++ b/esy.lock/opam/ppx_deriving.4.2.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_deriving"
+doc: "https://whitequark.github.io/ppx_deriving"
+bug-reports: "https://github.com/whitequark/ppx_deriving/issues"
+dev-repo: "git+https://github.com/whitequark/ppx_deriving.git"
+tags: [ "syntax" ]
+substs: [ "pkg/META" ]
+build: [
+  [
+    "ocaml"
+    "pkg/build.ml"
+    "native=%{ocaml:native-dynlink}%"
+    "native-dynlink=%{ocaml:native-dynlink}%"
+  ]
+  [
+    "ocamlbuild"
+    "-classic-display"
+    "-use-ocamlfind"
+    "src_test/test_ppx_deriving.byte"
+    "--"
+  ] {with-test}
+  [make "doc"] {with-doc}
+]
+depends: [
+  "ocaml" {> "4.03.0"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build & >= "1.6.0"}
+  "cppo" {build}
+  "cppo_ocamlbuild" {build}
+  "ocaml-migrate-parsetree"
+  "ppx_derivers"
+  "ppx_tools" {>= "4.02.3"}
+  "result"
+  "ounit" {with-test}
+]
+available: opam-version >= "1.2"
+synopsis: "Type-driven code generation for OCaml >=4.02"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks."""
+url {
+  src: "https://github.com/ocaml-ppx/ppx_deriving/archive/v4.2.1.tar.gz"
+  checksum: "md5=2195fccf2a527c3ff9ec5b4e36e2f0a8"
+}

--- a/esy.lock/opam/ppx_deriving_yojson.3.3/opam
+++ b/esy.lock/opam/ppx_deriving_yojson.3.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/whitequark/ppx_deriving_yojson"
+doc: "http://whitequark.github.io/ppx_deriving_yojson"
+bug-reports: "https://github.com/whitequark/ppx_deriving_yojson/issues"
+dev-repo: "git://github.com/whitequark/ppx_deriving_yojson.git"
+tags: [ "syntax" "json" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "yojson"
+  "result"
+  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_tools"    {build}
+  "ppxfind"      {build}
+  "dune"         {build & >= "1.2"}
+  "cppo"         {build}
+  "ounit"        {with-test}
+]
+conflicts: [
+  "ppx_deriving" {= "4.2"}
+]
+synopsis: "JSON codec generator for OCaml"
+description: """
+ppx_deriving_yojson is a ppx_deriving plugin that provides
+a JSON codec generator."""
+url {
+  src: "https://github.com/ocaml-ppx/ppx_deriving_yojson/archive/v3.3.tar.gz"
+  checksum: "sha512=e04ee424d89423ca891e018b3ea6e3f5f1e3714bd1ec1b07187143da1a646e51d068d1c09bc794e25b5b5be00ccb517212f62853ec66c17969a9795ba88fae6a"
+}

--- a/esy.lock/opam/ppx_tools.5.1+4.06.0/opam
+++ b/esy.lock/opam/ppx_tools.5.1+4.06.0/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "alain.frisch@lexifi.com"
+authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools.git"
+tags: [ "syntax" ]
+build: [[make "all"]]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "ppx_tools"]]
+depends: [
+  "ocaml" {>= "4.06.0" & < "4.08"}
+  "ocamlfind" {>= "1.5.0"}
+]
+synopsis: "Tools for authors of ppx rewriters and other syntactic tools"
+flags: light-uninstall
+url {
+  src: "https://github.com/ocaml-ppx/ppx_tools/archive/5.1+4.06.0.tar.gz"
+  checksum: "md5=6ba2e9690b1f579ba562b86022d1c308"
+}

--- a/esy.lock/opam/ppxfind.1.2/opam
+++ b/esy.lock/opam/ppxfind.1.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+license: "BSD3"
+homepage: "https://github.com/diml/ppxfind"
+bug-reports: "https://github.com/diml/ppxfind/issues"
+dev-repo: "git://github.com/diml/ppxfind.git"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "jbuilder" {build & >= "1.0+beta16"}
+  "ocaml-migrate-parsetree"
+  "ocamlfind"
+]
+synopsis: "ocamlfind ppx tool"
+description: """
+Ppxfind is a small command line tool that among other things allows
+to use old style ppx rewriters with jbuilder."""
+url {
+  src:
+    "https://github.com/diml/ppxfind/releases/download/1.2/ppxfind-1.2.tbz"
+  checksum: "md5=3c6f81800bb816e190a64f9898481f82"
+}
+conflicts: [ "dune" {= "1.2.0" | = "1.2.1"} ]

--- a/esy.lock/overrides/opam__s__ppx__deriving_opam__c__4.2.1_opam_override/files/ppx_deriving-4.2.1.patch
+++ b/esy.lock/overrides/opam__s__ppx__deriving_opam__c__4.2.1_opam_override/files/ppx_deriving-4.2.1.patch
@@ -1,0 +1,78 @@
+--- ./pkg/topkg.ml
++++ ./pkg/topkg.ml
+@@ -152,7 +152,63 @@
+ module Exts : Exts = struct
+   let interface = [".mli"; ".cmi"; ".cmti"]
+   let interface_opt = ".cmx" :: interface
+-  let c_library = if Sys.win32 then [".lib"] else [".a"]
++  let c_library =
++    match Sys.win32 with
++    | false -> [".a"]
++    | true ->
++      let input_line ch =
++        try
++          let s = input_line ch in
++          let len = String.length s in
++          if len > 0 && Sys.os_type = "Win32" && s.[len-1] = '\r' then
++            Some (String.sub s 0 (pred len))
++          else
++            Some s
++        with
++        | End_of_file -> None
++      in
++      let rec get_ext_lib ch =
++        match input_line ch with
++        | None -> ".a"
++        | Some s ->
++          let len = String.length s in
++          if len < 11 || s.[0] <> 'e' || String.sub s 0 9 <> "ext_lib: " then
++            get_ext_lib ch
++          else
++            String.sub s 9 (len - 9)
++      in
++      let get_ext_lib fln =
++        let ch = open_in fln in
++        let ch_closed = ref false in
++        try
++          let res = get_ext_lib ch in
++          ch_closed := true;
++          close_in ch ;
++          res
++        with
++        | x when !ch_closed = false ->
++          close_in_noerr ch;
++          raise x
++      in
++      let e_null = if Sys.win32 then " 2>NUL" else " 2>/dev/null" in
++      let fln = Filename.temp_file "get_ext" ".txt" in
++      let cleanup = lazy (try Sys.remove fln with Sys_error _ -> ()) in
++      try
++        let qfln = Filename.quote fln in
++        let cmd = "ocamlfind ocamlc -config > " ^ qfln ^ e_null in
++        let ec = Sys.command cmd in
++        if ec <> 0 then (
++          let cmd = "ocamlc -config > " ^ qfln ^ e_null in
++          let ec = Sys.command cmd in
++          if ec <> 0 then
++            failwith (Printf.sprintf "couldn't call ocamlc -config");
++        );
++        let res = get_ext_lib fln in
++        Lazy.force cleanup;
++        [res]
++      with
++      | x -> Lazy.force cleanup; raise x
++
+   let c_dll_library = if Sys.win32 then [".dll"] else [".so"]
+   let library = [".cma"; ".cmxa"; ".cmxs"] @ c_library
+   let module_library = (interface_opt @ library)
+@@ -258,7 +314,9 @@
+     let src, dst =
+       if not auto then src, dst else
+       let dst = match dst with
+-      | None -> Some (Filename.basename src)
++      | None ->
++        let src = if Sys.os_type <> "Win32" then src else src ^ ".exe" in
++        Some (Filename.basename src)
+       | Some _ as dst -> dst
+       in
+       let src = if Env.native then src ^ ".native" else src ^ ".byte" in

--- a/esy.lock/overrides/opam__s__ppx__deriving_opam__c__4.2.1_opam_override/package.json
+++ b/esy.lock/overrides/opam__s__ppx__deriving_opam__c__4.2.1_opam_override/package.json
@@ -1,0 +1,15 @@
+{
+  "build": [
+    [
+      "bash",
+      "-c",
+      "#{os == 'windows' ? 'patch -p1 < ppx_deriving-4.2.1.patch' : 'true'}"
+    ],
+    [
+      "ocaml",
+      "pkg/build.ml",
+      "native=true",
+      "native-dynlink=true"
+    ]
+  ]
+}

--- a/renderer-macos/lib/Styles.re
+++ b/renderer-macos/lib/Styles.re
@@ -1,5 +1,8 @@
+open CocoaTypes;
 open Layout;
 open BriskStylableText;
+
+type viewStyle = [ | `Border(Border.t) | `Background(Color.t)];
 
 type textStyle = [
   | `Color(Color.t)
@@ -11,6 +14,25 @@ type textStyle = [
 ];
 
 let flushTextStyle = BriskStylableText.applyChanges;
+
+let setViewStyle = (view: view, attr: [> viewStyle]) =>
+  switch (attr) {
+  | `Background(({r, g, b, a}: Color.t)) =>
+    BriskView.setBackgroundColor(view, r, g, b, a)
+  | `Border(({width, radius, color}: Border.t)) =>
+    if (!isUndefined(width)) {
+      BriskView.setBorderWidth(view, width);
+    };
+    if (!isUndefined(radius)) {
+      BriskView.setBorderRadius(view, radius);
+    };
+
+    if (color !== Color.undefined) {
+      let {r, g, b, a}: Color.t = color;
+      BriskView.setBorderColor(view, r, g, b, a);
+    }
+  | _ => ()
+  };
 
 let setTextStyle = (txt: text, attr: [> textStyle]) =>
   switch (attr) {

--- a/renderer-macos/lib/Styles.re
+++ b/renderer-macos/lib/Styles.re
@@ -1,0 +1,58 @@
+open Layout;
+open BriskStylableText;
+
+type textStyle = [
+  | `Color(Color.t)
+  | `Font(Font.t)
+  | `Kern(float)
+  | `Align(Alignment.t)
+  | `LineBreak(LineBreak.t)
+  | `LineSpacing(float)
+];
+
+let flushTextStyle = BriskStylableText.applyChanges;
+
+let setTextStyle = (txt: text, attr: [> textStyle]) =>
+  switch (attr) {
+  | `Font(({family, size, weight}: Font.t)) =>
+    let weight =
+      switch (weight) {
+      | `UltraLight => (-0.8)
+      | `Thin => (-0.6)
+      | `Light => (-0.4)
+      | `Regular => 0.
+      | `Medium => 0.23
+      | `Semibold => 0.3
+      | `Bold => 0.4
+      | `Heavy => 0.56
+      | `Black => 0.62
+      };
+    setFont(txt, family, size, weight);
+  | `Kern(kern) => setKern(txt, kern)
+  | `Align(align) =>
+    setAlignment(
+      txt,
+      switch (align) {
+      | `Left => 0
+      | `Right => 1
+      | `Center => 2
+      | `Justified => 3
+      | `Natural => 4
+      },
+    )
+  | `LineBreak(mode) =>
+    setLineBreak(
+      txt,
+      switch (mode) {
+      | `WordWrap => 0
+      | `CharWrap => 1
+      | `Clip => 2
+      | `TruncateHead => 3
+      | `TruncateTale => 4
+      | `TruncateMiddle => 5
+      },
+    )
+  | `LineSpacing(spacing) => setLineSpacing(txt, spacing)
+  | `Color(({r, g, b, a}: Color.t)) => setColor(txt, r, g, b, a)
+  | _ => ()
+  };

--- a/renderer-macos/lib/Styles.re
+++ b/renderer-macos/lib/Styles.re
@@ -13,7 +13,7 @@ type textStyle = [
   | `LineSpacing(float)
 ];
 
-let flushTextStyle = BriskStylableText.applyChanges;
+let commitTextStyle = BriskStylableText.applyChanges;
 
 let setViewStyle = (view: view, attr: [> viewStyle]) =>
   switch (attr) {
@@ -30,7 +30,7 @@ let setViewStyle = (view: view, attr: [> viewStyle]) =>
     if (color !== Color.undefined) {
       let {r, g, b, a}: Color.t = color;
       BriskView.setBorderColor(view, r, g, b, a);
-    }
+    };
   | _ => ()
   };
 

--- a/renderer-macos/lib/bindings/BriskButton.re
+++ b/renderer-macos/lib/bindings/BriskButton.re
@@ -36,8 +36,12 @@ external setBezelStyle: (t, bezelStyle) => unit =
   "ml_BriskButton_setBezelStyle_bc" "ml_BriskButton_setBezelStyle";
 
 [@noalloc]
-external setIsBordered: (t, bool) => unit =
+external setIsBordered: (t, [@untagged] int) => unit =
   "ml_BriskButton_setIsBordered_bc" "ml_BriskButton_setIsBordered";
+
+let setIsBordered = (btn, bordered) => {
+  setIsBordered(btn, bordered ? 1 : 0);
+};
 
 let make = (~type_=?, ~bezel=?, ~title=?, ~onClick=?, ()) => {
   let btn = make();

--- a/renderer-macos/lib/bindings/BriskStylableText.re
+++ b/renderer-macos/lib/bindings/BriskStylableText.re
@@ -1,0 +1,39 @@
+type text = CocoaTypes.view;
+
+[@noalloc]
+external applyChanges: text => unit =
+  "ml_BriskStylableText_applyChanges" "ml_BriskStylableText_applyChanges";
+
+[@noalloc]
+external setFont: (text, string, [@unboxed] float, [@unboxed] float) => unit =
+  "ml_BriskStylableText_setFont" "ml_BriskStylableText_setFont";
+
+[@noalloc]
+external setKern: (text, [@unboxed] float) => unit =
+  "ml_BriskStylableText_setKern_bc" "ml_BriskStylableText_setKern";
+
+[@noalloc]
+external setColor:
+  (
+    text,
+    [@unboxed] float,
+    [@unboxed] float,
+    [@unboxed] float,
+    [@unboxed] float
+  ) =>
+  unit =
+  "ml_BriskStylableText_setColor_bc" "ml_BriskStylableText_setColor";
+
+[@noalloc]
+external setAlignment: (text, [@untagged] int) => unit =
+  "ml_BriskStylableText_setAlignment_bc" "ml_BriskStylableText_setAlignment";
+
+[@noalloc]
+external setLineBreak: (text, [@untagged] int) => unit =
+  "ml_BriskStylableText_setLineBreakMode_bc"
+  "ml_BriskStylableText_setLineBreakMode";
+
+[@noalloc]
+external setLineSpacing: (text, [@unboxed] float) => unit =
+  "ml_BriskStylableText_setLineSpacing_b\n\n\n\n\n\n\nc"
+  "ml_BriskStylableText_setLineSpacing";

--- a/renderer-macos/lib/bindings/BriskTextView.re
+++ b/renderer-macos/lib/bindings/BriskTextView.re
@@ -15,10 +15,6 @@ external setStringValue: (t, string) => unit =
   "ml_BriskTextView_setStringValue";
 
 [@noalloc]
-external setCornerRadius: (t, [@unboxed] float) => unit =
-  "ml_BriskTextView_setCornerRadius_bc" "ml_BriskTextView_setCornerRadius";
-
-[@noalloc]
 external setBackgroundColor:
   (
     t,

--- a/renderer-macos/lib/bindings/BriskTextView.re
+++ b/renderer-macos/lib/bindings/BriskTextView.re
@@ -15,38 +15,6 @@ external setStringValue: (t, string) => unit =
   "ml_BriskTextView_setStringValue";
 
 [@noalloc]
-external setFont: (t, string, [@unboxed] float, [@unboxed] float) => unit =
-  "ml_BriskTextView_setFont" "ml_BriskTextView_setFont";
-
-[@noalloc]
-external setKern: (t, [@unboxed] float) => unit =
-  "ml_BriskTextView_setKern_bc" "ml_BriskTextView_setKern";
-
-[@noalloc]
-external setColor:
-  (
-    t,
-    [@unboxed] float,
-    [@unboxed] float,
-    [@unboxed] float,
-    [@unboxed] float
-  ) =>
-  unit =
-  "ml_BriskTextView_setColor_bc" "ml_BriskTextView_setColor";
-
-[@noalloc]
-external setAlignment: (t, [@untagged] int) => unit =
-  "ml_BriskTextView_setAlignment_bc" "ml_BriskTextView_setAlignment";
-
-[@noalloc]
-external setLineBreak: (t, [@untagged] int) => unit =
-  "ml_BriskTextView_setLineBreakMode_bc" "ml_BriskTextView_setLineBreakMode";
-
-[@noalloc]
-external setLineSpacing: (t, [@unboxed] float) => unit =
-  "ml_BriskTextView_setLineSpacing_bc" "ml_BriskTextView_setLineSpacing";
-
-[@noalloc]
 external setCornerRadius: (t, [@unboxed] float) => unit =
   "ml_BriskTextView_setCornerRadius_bc" "ml_BriskTextView_setCornerRadius";
 

--- a/renderer-macos/lib/bindings/BriskView.re
+++ b/renderer-macos/lib/bindings/BriskView.re
@@ -21,6 +21,10 @@ external setBorderWidth: (t, [@unboxed] float) => unit =
   "ml_NSView_setBorderWidth_bc" "ml_NSView_setBorderWidth";
 
 [@noalloc]
+external setBorderRadius: (t, [@unboxed] float) => unit =
+  "ml_NSView_setBorderRadius_bc" "ml_NSView_setBorderRadius";
+
+[@noalloc]
 external setBorderColor:
   (
     t,

--- a/renderer-macos/lib/components/Button.re
+++ b/renderer-macos/lib/components/Button.re
@@ -1,7 +1,7 @@
 open Brisk;
 open Layout;
 
-type attr = [ Layout.style | Styles.textStyle | `Background(Color.t)];
+type attr = [ Layout.style | Styles.textStyle | Styles.viewStyle];
 
 type style = list(attr);
 
@@ -21,16 +21,11 @@ let make =
         style
         |> List.iter(attr =>
              switch (attr) {
-             | `Background(({r, g, b, a}: Color.t)) =>
+             | `Background(_) =>
                BriskButton.setIsBordered(view, false);
-               BriskView.setBackgroundColor(view, r, g, b, a);
-             | `Border(({width, color}: Border.t)) =>
-               if (!isUndefined(width)) {
-                 BriskView.setBorderWidth(view, width);
-               };
-               let {r, g, b, a}: Color.t = color;
-               BriskView.setBorderColor(view, r, g, b, a);
+               Styles.setViewStyle(view, attr);
              | #Styles.textStyle => Styles.setTextStyle(view, attr)
+             | #Styles.viewStyle => Styles.setViewStyle(view, attr)
              | #Layout.style => ()
              }
            );

--- a/renderer-macos/lib/components/Button.re
+++ b/renderer-macos/lib/components/Button.re
@@ -1,7 +1,7 @@
 open Brisk;
 open Layout;
 
-type attr = [ Layout.style | `Color(Color.t) | `Background(Color.t)];
+type attr = [ Layout.style | Styles.textStyle | `Background(Color.t)];
 
 type style = list(attr);
 
@@ -21,18 +21,20 @@ let make =
         style
         |> List.iter(attr =>
              switch (attr) {
-             | `Color(_) => ()
              | `Background(({r, g, b, a}: Color.t)) =>
-               BriskView.setBackgroundColor(view, r, g, b, a)
+               BriskButton.setIsBordered(view, false);
+               BriskView.setBackgroundColor(view, r, g, b, a);
              | `Border(({width, color}: Border.t)) =>
                if (!isUndefined(width)) {
                  BriskView.setBorderWidth(view, width);
                };
                let {r, g, b, a}: Color.t = color;
                BriskView.setBorderColor(view, r, g, b, a);
+             | #Styles.textStyle => Styles.setTextStyle(view, attr)
              | #Layout.style => ()
              }
            );
+        Styles.flushTextStyle(view);
         node;
       },
       children,

--- a/renderer-macos/lib/components/Button.re
+++ b/renderer-macos/lib/components/Button.re
@@ -29,7 +29,7 @@ let make =
              | #Layout.style => ()
              }
            );
-        Styles.flushTextStyle(view);
+        Styles.commitTextStyle(view);
         node;
       },
       children,

--- a/renderer-macos/lib/components/Image.re
+++ b/renderer-macos/lib/components/Image.re
@@ -1,7 +1,7 @@
 open Brisk;
 open Layout;
 
-type attr = [ Layout.style];
+type attr = [ Layout.style | Styles.viewStyle];
 
 type style = list(attr);
 
@@ -25,10 +25,11 @@ let make = (~style=[], ~source, children) =>
         let view = BriskImage.make(~source, ());
         {view, layoutNode: makeLayoutNode(~measure, ~style, view)};
       },
-      configureInstance: (~isFirstRender as _, {view: _} as node) => {
+      configureInstance: (~isFirstRender as _, {view} as node) => {
         style
         |> List.iter(attr =>
              switch (attr) {
+             | #Styles.viewStyle => Styles.setViewStyle(view, attr)
              | #Layout.style => ()
              }
            );

--- a/renderer-macos/lib/components/Text.re
+++ b/renderer-macos/lib/components/Text.re
@@ -1,12 +1,7 @@
 open Brisk;
 open Layout;
 
-type attr = [
-  Layout.style
-  | Styles.textStyle
-  | `Background(Color.t)
-  | `CornerRadius(float)
-];
+type attr = [ Layout.style | Styles.textStyle | Styles.viewStyle];
 
 type style = list(attr);
 
@@ -31,21 +26,21 @@ let make = (~style=[], ~value, children) =>
         {view, layoutNode: makeLayoutNode(~measure, ~style, view)};
       },
       configureInstance: (~isFirstRender as _, {view} as node) => {
-      style
-      |> List.iter(attr =>
-           switch (attr) {
-           | `Background(({r, g, b, a}: Color.t)) =>
-             BriskTextView.setBackgroundColor(view, r, g, b, a)
-           | `CornerRadius(r) => BriskTextView.setCornerRadius(view, r)
-           | `Padding({left, top, right, bottom}) =>
-             BriskTextView.setPadding(view, left, top, right, bottom)
-           | #Styles.textStyle => Styles.setTextStyle(view, attr)
-           | #Layout.style => ()
-           }
-         );
-      Styles.flushTextStyle(view);
-      node;
-    },
+        style
+        |> List.iter(attr =>
+             switch (attr) {
+             | `Padding({left, top, right, bottom}) =>
+               BriskTextView.setPadding(view, left, top, right, bottom)
+             | `Background(({r, g, b, a}: Color.t)) =>
+               BriskTextView.setBackgroundColor(view, r, g, b, a)
+             | #Styles.textStyle => Styles.setTextStyle(view, attr)
+             | #Styles.viewStyle => Styles.setViewStyle(view, attr)
+             | #Layout.style => ()
+             }
+           );
+        Styles.flushTextStyle(view);
+        node;
+      },
       children,
     }
   );

--- a/renderer-macos/lib/components/Text.re
+++ b/renderer-macos/lib/components/Text.re
@@ -3,14 +3,9 @@ open Layout;
 
 type attr = [
   Layout.style
-  | `Font(Font.t)
-  | `Kern(float)
-  | `Align(Alignment.t)
-  | `LineBreak(LineBreak.t)
-  | `LineSpacing(float)
-  | `CornerRadius(float)
+  | Styles.textStyle
   | `Background(Color.t)
-  | `Color(Color.t)
+  | `CornerRadius(float)
 ];
 
 type style = list(attr);
@@ -39,45 +34,16 @@ let make = (~style=[], ~value, children) =>
       style
       |> List.iter(attr =>
            switch (attr) {
-           | `Font(({family, size, weight}: Font.t)) =>
-             let weight =
-               switch (weight) {
-               | `UltraLight => (-0.8)
-               | `Thin => (-0.6)
-               | `Light => (-0.4)
-               | `Regular => 0.
-               | `Medium => 0.23
-               | `Semibold => 0.3
-               | `Bold => 0.4
-               | `Heavy => 0.56
-               | `Black => 0.62
-               };
-             BriskTextView.setFont(view, family, size, weight);
-           | `Kern(kern) => BriskTextView.setKern(view, kern)
-           | `Align(align) =>
-             BriskTextView.setAlignment(
-               view,
-               switch (align) {
-               | `Left => 0
-               | `Right => 1
-               | `Center => 2
-               | `Justified => 3
-               | `Natural => 4
-               },
-             )
-           | `LineBreak(mode) => BriskTextView.setLineBreak(view, mode)
-           | `LineSpacing(spacing) =>
-             BriskTextView.setLineSpacing(view, spacing)
-           | `CornerRadius(r) => BriskTextView.setCornerRadius(view, r)
-           | `Color(({r, g, b, a}: Color.t)) =>
-             BriskTextView.setColor(view, r, g, b, a)
            | `Background(({r, g, b, a}: Color.t)) =>
              BriskTextView.setBackgroundColor(view, r, g, b, a)
+           | `CornerRadius(r) => BriskTextView.setCornerRadius(view, r)
            | `Padding({left, top, right, bottom}) =>
              BriskTextView.setPadding(view, left, top, right, bottom)
+           | #Styles.textStyle => Styles.setTextStyle(view, attr)
            | #Layout.style => ()
            }
          );
+      Styles.flushTextStyle(view);
       node;
     },
       children,

--- a/renderer-macos/lib/components/Text.re
+++ b/renderer-macos/lib/components/Text.re
@@ -38,7 +38,7 @@ let make = (~style=[], ~value, children) =>
              | #Layout.style => ()
              }
            );
-        Styles.flushTextStyle(view);
+        Styles.commitTextStyle(view);
         node;
       },
       children,

--- a/renderer-macos/lib/components/View.re
+++ b/renderer-macos/lib/components/View.re
@@ -1,7 +1,7 @@
 open Brisk;
 open Layout;
 
-type attr = [ Layout.style | `Background(Color.t)];
+type attr = [ Layout.style | Styles.viewStyle];
 
 type style = list(attr);
 
@@ -18,14 +18,7 @@ let make = (~style: style=[], children) =>
         style
         |> List.iter(attr =>
              switch (attr) {
-             | `Background(({r, g, b, a}: Color.t)) =>
-               BriskView.setBackgroundColor(view, r, g, b, a)
-             | `Border(({width, color}: Border.t)) =>
-               if (!isUndefined(width)) {
-                 BriskView.setBorderWidth(view, width);
-               };
-               let {r, g, b, a}: Color.t = color;
-               BriskView.setBorderColor(view, r, g, b, a);
+             | #Styles.viewStyle => Styles.setViewStyle(view, attr)
              | #Layout.style => ()
              }
            );

--- a/renderer-macos/lib/dune
+++ b/renderer-macos/lib/dune
@@ -10,12 +10,14 @@
  (install_c_headers BriskCocoa
                     BriskApplicationDelegate
                     BriskWindowDelegate
+                    BriskStylableText
                     )
  (c_names BriskCocoa
           BriskApplication BriskApplicationDelegate
           BriskWindow BriskWindowDelegate
           BriskMenu
           BriskView
+          BriskStylableText
           BriskTextView
           BriskImage
           BriskButton

--- a/renderer-macos/lib/stubs/BriskButton.c
+++ b/renderer-macos/lib/stubs/BriskButton.c
@@ -1,6 +1,7 @@
 #import "BriskCocoa.h"
+#import "BriskStylableText.h"
 
-@interface BriskButton : NSButton
+@interface BriskButton : NSButton <BriskStylableText>
 
 @property(nonatomic, assign) value _callback;
 
@@ -9,6 +10,31 @@
 @end
 
 @implementation BriskButton
+
+@synthesize attributedString;
+@synthesize attributedProps;
+@synthesize paragraphStyle;
+
+- (id)init {
+  self = [super init];
+
+  if (self) {
+    self.attributedString = [[NSMutableAttributedString alloc] init];
+    self.attributedProps = [NSMutableDictionary dictionary];
+    self.paragraphStyle =
+        [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+
+    self.attributedProps[NSParagraphStyleAttributeName] = self.paragraphStyle;
+  }
+
+  return self;
+}
+
+- (void)applyTextStyle {
+  NSRange range = NSMakeRange(0, self.attributedString.length);
+  [self.attributedString setAttributes:self.attributedProps range:range];
+  [self setAttributedTitle:self.attributedString];
+}
 
 - (void)setCallback:(value)callback {
   if (self._callback) {
@@ -48,10 +74,19 @@ CAMLprim value ml_BriskButton_setTitle(BriskButton *btn, value str_v) {
   CAMLparam1(str_v);
 
   NSString *str = [NSString stringWithUTF8String:String_val(str_v)];
-  [btn setTitle:str];
+  [btn.attributedString.mutableString setString:str];
 
   CAMLreturn(Val_unit);
 }
+
+// CAMLprim value ml_BriskButton_setTitle(BriskButton *btn, value str_v) {
+//   CAMLparam1(str_v);
+
+//   NSString *str = [NSString stringWithUTF8String:String_val(str_v)];
+//   [btn setTitle:str];
+
+//   CAMLreturn(Val_unit);
+// }
 
 void ml_BriskButton_setButtonType(BriskButton *btn, intnat type) {
   [btn setButtonType:type];
@@ -76,14 +111,14 @@ CAMLprim value ml_BriskButton_setBezelStyle_bc(BriskButton *btn,
   CAMLreturn(Val_unit);
 }
 
-void ml_BriskButton_setIsBordered(BriskButton *btn, BOOL bordered) {
-  btn.bordered = bordered;
+void ml_BriskButton_setIsBordered(BriskButton *btn, intnat bordered) {
+  [btn setBordered:bordered];
 }
 
 CAMLprim value ml_BriskButton_setIsBordered_bc(BriskButton *btn,
                                                value bordered_v) {
   CAMLparam1(bordered_v);
 
-  ml_BriskButton_setIsBordered(btn, Bool_val(bordered_v));
+  ml_BriskButton_setIsBordered(btn, Int_val(bordered_v));
   CAMLreturn(Val_unit);
 }

--- a/renderer-macos/lib/stubs/BriskButton.c
+++ b/renderer-macos/lib/stubs/BriskButton.c
@@ -79,15 +79,6 @@ CAMLprim value ml_BriskButton_setTitle(BriskButton *btn, value str_v) {
   CAMLreturn(Val_unit);
 }
 
-// CAMLprim value ml_BriskButton_setTitle(BriskButton *btn, value str_v) {
-//   CAMLparam1(str_v);
-
-//   NSString *str = [NSString stringWithUTF8String:String_val(str_v)];
-//   [btn setTitle:str];
-
-//   CAMLreturn(Val_unit);
-// }
-
 void ml_BriskButton_setButtonType(BriskButton *btn, intnat type) {
   [btn setButtonType:type];
 }
@@ -112,7 +103,7 @@ CAMLprim value ml_BriskButton_setBezelStyle_bc(BriskButton *btn,
 }
 
 void ml_BriskButton_setIsBordered(BriskButton *btn, intnat bordered) {
-  [btn setBordered:bordered];
+  btn.bordered = bordered;
 }
 
 CAMLprim value ml_BriskButton_setIsBordered_bc(BriskButton *btn,

--- a/renderer-macos/lib/stubs/BriskStylableText.c
+++ b/renderer-macos/lib/stubs/BriskStylableText.c
@@ -1,0 +1,107 @@
+#import "BriskStylableText.h"
+
+void ml_BriskStylableText_applyChanges(id<BriskStylableText> txt) {
+  [txt applyTextStyle];
+}
+
+CAMLprim value ml_BriskStylableText_setFont(id<BriskStylableText> txt,
+                                            value fontName_v, double fontSize,
+                                            double fontWeight) {
+  CAMLparam1(fontName_v);
+
+  NSString *fontName = [NSString stringWithUTF8String:String_val(fontName_v)];
+  NSFont *font;
+
+  if (fontName.length > 0) {
+    NSDictionary *attributes = @{
+      NSFontFaceAttribute : fontName,
+      NSFontTraitsAttribute :
+          @{NSFontWeightTrait : [NSNumber numberWithDouble:fontWeight]}
+    };
+
+    NSFontDescriptor *descriptor =
+        [NSFontDescriptor fontDescriptorWithFontAttributes:attributes];
+
+    font = [NSFont fontWithDescriptor:descriptor size:(CGFloat)fontSize];
+  } else {
+    font = [NSFont systemFontOfSize:(CGFloat)fontSize weight:fontWeight];
+  }
+
+  txt.attributedProps[NSFontAttributeName] = font;
+
+  CAMLreturn(Val_unit);
+}
+
+void ml_BriskStylableText_setColor(id<BriskStylableText> txt, double red,
+                                   double green, double blue, double alpha) {
+  txt.attributedProps[NSForegroundColorAttributeName] =
+      [NSColor colorWithRed:red green:green blue:blue alpha:alpha];
+}
+
+CAMLprim value ml_BriskStylableText_setColor_bc(id<BriskStylableText> txt,
+                                                value red_v, value green_v,
+                                                value blue_v, value alpha_v) {
+  CAMLparam4(red_v, blue_v, green_v, alpha_v);
+
+  ml_BriskStylableText_setColor(txt, Double_val(red_v), Double_val(blue_v),
+                                Double_val(green_v), Double_val(alpha_v));
+
+  CAMLreturn(Val_unit);
+}
+
+void ml_BriskStylableText_setAlignment(id<BriskStylableText> txt, int align) {
+  txt.paragraphStyle.alignment = align;
+  txt.attributedProps[NSParagraphStyleAttributeName] = txt.paragraphStyle;
+}
+
+CAMLprim value ml_BriskStylableText_setAlignment_bc(id<BriskStylableText> txt,
+                                                    value align_v) {
+  CAMLparam1(align_v);
+
+  ml_BriskStylableText_setAlignment(txt, Int_val(align_v));
+
+  CAMLreturn(Val_unit);
+}
+
+void ml_BriskStylableText_setLineBreakMode(id<BriskStylableText> txt,
+                                           int mode) {
+  txt.paragraphStyle.lineBreakMode = mode;
+  txt.attributedProps[NSParagraphStyleAttributeName] = txt.paragraphStyle;
+}
+
+CAMLprim value ml_BriskStylableText_setLineBreakMode_bc(
+    id<BriskStylableText> txt, value mode_v) {
+  CAMLparam1(mode_v);
+
+  ml_BriskStylableText_setLineBreakMode(txt, Int_val(mode_v));
+
+  CAMLreturn(Val_unit);
+}
+
+void ml_BriskStylableText_setLineSpacing(id<BriskStylableText> txt,
+                                         double spacing) {
+  txt.paragraphStyle.lineSpacing = spacing;
+  txt.attributedProps[NSParagraphStyleAttributeName] = txt.paragraphStyle;
+}
+
+CAMLprim value ml_BriskStylableText_setLineSpacing_bc(id<BriskStylableText> txt,
+                                                      value spacing_v) {
+  CAMLparam1(spacing_v);
+
+  ml_BriskStylableText_setLineSpacing(txt, Double_val(spacing_v));
+
+  CAMLreturn(Val_unit);
+}
+
+void ml_BriskStylableText_setKern(id<BriskStylableText> txt, double kern) {
+  txt.attributedProps[NSKernAttributeName] = [NSNumber numberWithDouble:kern];
+}
+
+CAMLprim value ml_BriskStylableText_setKern_bc(id<BriskStylableText> txt,
+                                               value kern_v) {
+  CAMLparam1(kern_v);
+
+  ml_BriskStylableText_setKern(txt, Double_val(kern_v));
+
+  CAMLreturn(Val_unit);
+}

--- a/renderer-macos/lib/stubs/BriskStylableText.h
+++ b/renderer-macos/lib/stubs/BriskStylableText.h
@@ -1,0 +1,11 @@
+#import "BriskCocoa.h"
+
+@protocol BriskStylableText
+
+@property(nonatomic, assign) NSMutableAttributedString *attributedString;
+@property(nonatomic, assign) NSMutableDictionary *attributedProps;
+@property(nonatomic, assign) NSMutableParagraphStyle *paragraphStyle;
+
+- (void)applyTextStyle;
+
+@end

--- a/renderer-macos/lib/stubs/BriskStylableText.h
+++ b/renderer-macos/lib/stubs/BriskStylableText.h
@@ -2,9 +2,9 @@
 
 @protocol BriskStylableText
 
-@property(nonatomic, assign) NSMutableAttributedString *attributedString;
-@property(nonatomic, assign) NSMutableDictionary *attributedProps;
-@property(nonatomic, assign) NSMutableParagraphStyle *paragraphStyle;
+@property(nonatomic, retain) NSMutableAttributedString *attributedString;
+@property(nonatomic, retain) NSMutableDictionary *attributedProps;
+@property(nonatomic, retain) NSMutableParagraphStyle *paragraphStyle;
 
 - (void)applyTextStyle;
 

--- a/renderer-macos/lib/stubs/BriskTextView.c
+++ b/renderer-macos/lib/stubs/BriskTextView.c
@@ -1,14 +1,15 @@
 #import "BriskCocoa.h"
+#import "BriskStylableText.h"
 
-@interface BriskTextView : NSTextView
-
-@property(nonatomic, assign) NSMutableAttributedString *attributedString;
-@property(nonatomic, assign) NSMutableDictionary *attributedProps;
-@property(nonatomic, assign) NSMutableParagraphStyle *paragraphStyle;
+@interface BriskTextView : NSTextView <BriskStylableText>
 
 @end
 
 @implementation BriskTextView
+
+@synthesize attributedString;
+@synthesize attributedProps;
+@synthesize paragraphStyle;
 
 - (id)init {
   self = [super init];
@@ -31,6 +32,13 @@
   return NO;
 }
 
+- (void)applyTextStyle {
+  NSRange range = NSMakeRange(0, self.attributedString.length);
+
+  [self.attributedString setAttributes:self.attributedProps range:range];
+  [[self textStorage] setAttributedString:self.attributedString];
+}
+
 @end
 
 BriskTextView *ml_BriskTextView_make() {
@@ -38,13 +46,6 @@ BriskTextView *ml_BriskTextView_make() {
   retainView(txt);
 
   return txt;
-}
-
-void ml_BriskTextView_applyAttributes(BriskTextView *txt) {
-  NSRange range = NSMakeRange(0, txt.attributedString.length);
-
-  [txt.attributedString setAttributes:txt.attributedProps range:range];
-  [[txt textStorage] setAttributedString:txt.attributedString];
 }
 
 double ml_BriskTextView_getTextWidth(BriskTextView *txt) {
@@ -72,56 +73,7 @@ CAMLprim value ml_BriskTextView_setStringValue(BriskTextView *txt,
   NSString *str = [NSString stringWithUTF8String:String_val(str_v)];
 
   [txt.attributedString.mutableString setString:str];
-
-  ml_BriskTextView_applyAttributes(txt);
-
-  CAMLreturn(Val_unit);
-}
-
-CAMLprim value ml_BriskTextView_setFont(BriskTextView *txt, value fontName_v,
-                                        double fontSize, double fontWeight) {
-  CAMLparam1(fontName_v);
-
-  NSString *fontName = [NSString stringWithUTF8String:String_val(fontName_v)];
-  NSFont *font;
-
-  if (fontName.length > 0) {
-    NSDictionary *attributes = @{
-      NSFontFaceAttribute : fontName,
-      NSFontTraitsAttribute :
-          @{NSFontWeightTrait : [NSNumber numberWithDouble:fontWeight]}
-    };
-
-    NSFontDescriptor *descriptor =
-        [NSFontDescriptor fontDescriptorWithFontAttributes:attributes];
-
-    font = [NSFont fontWithDescriptor:descriptor size:(CGFloat)fontSize];
-  } else {
-    font = [NSFont systemFontOfSize:(CGFloat)fontSize weight:fontWeight];
-  }
-
-  txt.attributedProps[NSFontAttributeName] = font;
-
-  ml_BriskTextView_applyAttributes(txt);
-
-  CAMLreturn(Val_unit);
-}
-
-void ml_BriskTextView_setColor(BriskTextView *txt, double red, double green,
-                               double blue, double alpha) {
-  txt.attributedProps[NSForegroundColorAttributeName] =
-      [NSColor colorWithRed:red green:green blue:blue alpha:alpha];
-
-  ml_BriskTextView_applyAttributes(txt);
-}
-
-CAMLprim value ml_BriskTextView_setColor_bc(BriskTextView *txt, value red_v,
-                                            value green_v, value blue_v,
-                                            value alpha_v) {
-  CAMLparam4(red_v, blue_v, green_v, alpha_v);
-
-  ml_BriskTextView_setColor(txt, Double_val(red_v), Double_val(blue_v),
-                            Double_val(green_v), Double_val(alpha_v));
+  [txt applyTextStyle];
 
   CAMLreturn(Val_unit);
 }
@@ -143,68 +95,6 @@ CAMLprim value ml_BriskTextView_setBackgroundColor_bc(BriskTextView *txt,
   ml_BriskTextView_setBackgroundColor(txt, Double_val(red_v),
                                       Double_val(blue_v), Double_val(green_v),
                                       Double_val(alpha_v));
-
-  CAMLreturn(Val_unit);
-}
-
-void ml_BriskTextView_setAlignment(BriskTextView *txt, int align) {
-  txt.paragraphStyle.alignment = align;
-  txt.attributedProps[NSParagraphStyleAttributeName] = txt.paragraphStyle;
-
-  ml_BriskTextView_applyAttributes(txt);
-}
-
-CAMLprim value ml_BriskTextView_setAlignment_bc(BriskTextView *txt,
-                                                value align_v) {
-  CAMLparam1(align_v);
-
-  ml_BriskTextView_setAlignment(txt, Int_val(align_v));
-
-  CAMLreturn(Val_unit);
-}
-
-void ml_BriskTextView_setLineBreakMode(BriskTextView *txt, int mode) {
-  txt.paragraphStyle.lineBreakMode = mode;
-  txt.attributedProps[NSParagraphStyleAttributeName] = txt.paragraphStyle;
-
-  ml_BriskTextView_applyAttributes(txt);
-}
-
-CAMLprim value ml_BriskTextView_setLineBreakMode_bc(BriskTextView *txt,
-                                                    value mode_v) {
-  CAMLparam1(mode_v);
-
-  ml_BriskTextView_setLineBreakMode(txt, Int_val(mode_v));
-
-  CAMLreturn(Val_unit);
-}
-
-void ml_BriskTextView_setLineSpacing(BriskTextView *txt, double spacing) {
-  txt.paragraphStyle.lineSpacing = spacing;
-  txt.attributedProps[NSParagraphStyleAttributeName] = txt.paragraphStyle;
-
-  ml_BriskTextView_applyAttributes(txt);
-}
-
-CAMLprim value ml_BriskTextView_setLineSpacing_bc(BriskTextView *txt,
-                                                  value spacing_v) {
-  CAMLparam1(spacing_v);
-
-  ml_BriskTextView_setLineSpacing(txt, Double_val(spacing_v));
-
-  CAMLreturn(Val_unit);
-}
-
-void ml_BriskTextView_setKern(BriskTextView *txt, double kern) {
-  txt.attributedProps[NSKernAttributeName] = [NSNumber numberWithDouble:kern];
-
-  ml_BriskTextView_applyAttributes(txt);
-}
-
-CAMLprim value ml_BriskTextView_setKern_bc(BriskTextView *txt, value kern_v) {
-  CAMLparam1(kern_v);
-
-  ml_BriskTextView_setKern(txt, Double_val(kern_v));
 
   CAMLreturn(Val_unit);
 }

--- a/renderer-macos/lib/stubs/BriskTextView.c
+++ b/renderer-macos/lib/stubs/BriskTextView.c
@@ -99,20 +99,6 @@ CAMLprim value ml_BriskTextView_setBackgroundColor_bc(BriskTextView *txt,
   CAMLreturn(Val_unit);
 }
 
-void ml_BriskTextView_setCornerRadius(BriskTextView *txt, double radius) {
-  [txt setWantsLayer:YES];
-  [txt.layer setCornerRadius:(CGFloat)radius];
-}
-
-CAMLprim value ml_BriskTextView_setCornerRadius_bc(BriskTextView *txt,
-                                                   value radius_v) {
-  CAMLparam1(radius_v);
-
-  ml_BriskTextView_setCornerRadius(txt, Double_val(radius_v));
-
-  CAMLreturn(Val_unit);
-}
-
 void ml_BriskTextView_setPadding(BriskTextView *txt, double left, double top,
                                  __unused double right,
                                  __unused double bottom) {

--- a/renderer-macos/lib/stubs/BriskView.c
+++ b/renderer-macos/lib/stubs/BriskView.c
@@ -77,3 +77,16 @@ CAMLprim value ml_NSView_setBackgroundColor_bc(NSView *view, value red_v,
 
   CAMLreturn(Val_unit);
 }
+
+void ml_NSView_setBorderRadius(NSView *view, double radius) {
+  [view setWantsLayer:YES];
+  [view.layer setCornerRadius:(CGFloat)radius];
+}
+
+CAMLprim value ml_NSView_setBorderRadius_bc(NSView *view, value radius_v) {
+  CAMLparam1(radius_v);
+
+  ml_NSView_setBorderRadius(view, Double_val(radius_v));
+
+  CAMLreturn(Val_unit);
+}

--- a/renderer/lib/Color0.re
+++ b/renderer/lib/Color0.re
@@ -23,3 +23,5 @@ let transparent = rgba(0, 0, 0, 0.);
 
 let isTransparent: t => bool =
   ({r, g, b, a}) => 0. == r && 0. == g && 0. == b && 0. == a;
+
+let undefined = rgba(0, 0, 0, 0.);

--- a/renderer/lib/Layout.re
+++ b/renderer/lib/Layout.re
@@ -84,9 +84,10 @@ module Create = (Node: Flex.Spec.Node, Encoding: Flex.Spec.Encoding) => {
     | `AlignSelf(alignSelf) => {...style, alignSelf}
     | `Width(w) => {...style, width: int_of_scalar(w)}
     | `Height(h) => {...style, height: int_of_scalar(h)}
-    | `Border(({width, _}: Border.t)) => {
+    | `Border(({width, _}: Border.t)) =>
+      {
         ...style,
-        border: !isUndefined(width) ? int_of_scalar(width) : style.width,
+        border: !isUndefined(width) ? int_of_scalar(width) : style.border,
       }
     | `Padding({left, top, right, bottom}) => {
         ...style,

--- a/renderer/lib/Style.re
+++ b/renderer/lib/Style.re
@@ -84,11 +84,18 @@ module Create = (Encoding: Flex.Spec.Encoding) => {
   module Border = {
     type t = {
       width: scalar,
+      radius: scalar,
       color: Color0.t,
     };
 
-    let make = (~width=cssUndefined, ~color=Color0.transparent, ()) => {
-      let border: t = {width, color};
+    let make =
+        (
+          ~width=cssUndefined,
+          ~radius=cssUndefined,
+          ~color=Color0.undefined,
+          (),
+        ) => {
+      let border: t = {width, radius, color};
       `Border(border);
     };
 
@@ -103,7 +110,6 @@ module Create = (Encoding: Flex.Spec.Encoding) => {
   let align = Alignment.make;
   let lineBreak = LineBreak.make;
   let lineSpacing = f => `LineSpacing(f);
-  let cornerRadius = f => `CornerRadius(f);
 
   let width = (w: scalar) => `Width(w);
   let height = (h: scalar) => `Height(h);

--- a/tester-macos/bin/app.re
+++ b/tester-macos/bin/app.re
@@ -7,90 +7,99 @@ module BriskMenu = Menu;
 module Component = {
   [@noalloc] external lwt_start: unit => unit = "ml_lwt_iter";
 
-let component = Brisk.component("Other");
-let createElement = (~children as _, ()) =>
-  component(slots => {
-    let (state, setState, _slots: Brisk.Hooks.empty) =
-      Brisk.Hooks.state(None, slots);
+  let component = Brisk.component("Other");
+  let createElement = (~children as _, ()) =>
+    component(slots => {
+      let (state, setState, _slots: Brisk.Hooks.empty) =
+        Brisk.Hooks.state(None, slots);
 
-    switch (state) {
-    | Some(code) =>
-      <View
-        style=[
-          width(100.),
-          height(100.),
-          background(Color.rgb(0, 255, 0)),
-          border(~width=1., ~color=Color.rgb(0, 0, 255), ()),
-        ]>
-        <Button
-          style=[width(100.), height(100.)]
-          title={string_of_int(code)}
-          callback={() => setState(None)}
-        />
-        <Button
-          style=[width(100.), height(100.)]
-          title="Cell two"
-          callback={() => setState(None)}
-        />
-      </View>
-    | None =>
-      <View
-        style=[
-          position(~top=0., ~left=0., ~right=0., ~bottom=0., `Absolute),
-          width(600.),
-          height(400.),
-          background(Color.hex("#f7f8f9")),
-        ]>
-        <Text
-          style=[
-            font(~size=24., ~weight=`Medium, ()),
-            kern(0.5),
-            align(`Center),
-            color(Color.hex("#ffffff")),
-            background(Color.hex("#263ac5")),
-            padding(10.),
-          ]
-          value="Welcome to Brisk"
-        />
+      switch (state) {
+      | Some(code) =>
         <View
           style=[
-            justifyContent(`Center),
-            alignContent(`Center),
-            background(Color.hex("#eeeeee")),
+            width(100.),
+            height(100.),
+            background(Color.rgb(0, 255, 0)),
+            border(~width=1., ~color=Color.rgb(0, 0, 255), ()),
           ]>
-          <Image
-            style=[margin4(~top=10., ()), alignSelf(`Center)]
-            source={`Bundle("reason")}
+          <Button
+            style=[width(100.), height(100.), align(`Center)]
+            title={string_of_int(code)}
+            callback={() => setState(None)}
           />
-          <Text
-            style=[
-              font(~size=18., ()),
-              align(`Center),
-              alignSelf(`Center),
-              width(200.),
-              cornerRadius(10.),
-              color(Color.hex("#ffffff")),
-              background(Color.hexa("#263ac5", 0.9)),
-              margin(20.),
-              padding2(~h=10., ~v=10., ()),
-            ]
-            value="Text bubble"
+          <Button
+            style=[width(100.), height(100.), align(`Center)]
+            title="Cell two"
+            callback={() => setState(None)}
           />
         </View>
-        <Button
-          style=[width(400.), height(60.)]
-          title="Youre gonna have to wait a bit"
-          callback={() => {
-            lwt_start();
-            ignore(
-              Lwt_unix.sleep(1.)
-              >>= (_ => Lwt.return(setState(Some(100)))),
-            );
-          }}
-        />
-      </View>
-    };
-  });
+      | None =>
+        <View
+          style=[
+            position(~top=0., ~left=0., ~right=0., ~bottom=0., `Absolute),
+            width(600.),
+            height(400.),
+            background(Color.hex("#f7f8f9")),
+          ]>
+          <Text
+            style=[
+              font(~size=24., ~weight=`Medium, ()),
+              kern(0.5),
+              align(`Center),
+              color(Color.hex("#ffffff")),
+              background(Color.hex("#263ac5")),
+              padding(10.),
+            ]
+            value="Welcome to Brisk"
+          />
+          <View
+            style=[
+              justifyContent(`Center),
+              alignContent(`Center),
+              background(Color.hex("#eeeeee")),
+            ]>
+            <Image
+              style=[margin4(~top=10., ()), alignSelf(`Center)]
+              source={`Bundle("reason")}
+            />
+            <Text
+              style=[
+                font(~size=18., ()),
+                align(`Center),
+                alignSelf(`Center),
+                width(200.),
+                cornerRadius(10.),
+                color(Color.hex("#ffffff")),
+                background(Color.hexa("#263ac5", 0.9)),
+                margin(20.),
+                padding2(~h=10., ~v=10., ()),
+              ]
+              value="Text bubble"
+            />
+          </View>
+          <Button
+            style=[
+              width(400.),
+              height(60.),
+              margin4(~top=20., ()),
+              alignSelf(`Center),
+              font(~size=16., ()),
+              color(Color.hex("#ffffff")),
+              background(Color.hex("#263ac5")),
+              align(`Center),
+            ]
+            title="You're gonna have to wait a bit"
+            callback={() => {
+              lwt_start();
+              ignore(
+                Lwt_unix.sleep(1.)
+                >>= (_ => Lwt.return(setState(Some(100)))),
+              );
+            }}
+          />
+        </View>
+      };
+    });
 };
 
 let lwt_iter = () => {

--- a/tester-macos/bin/app.re
+++ b/tester-macos/bin/app.re
@@ -68,7 +68,7 @@ module Component = {
                 align(`Center),
                 alignSelf(`Center),
                 width(200.),
-                cornerRadius(10.),
+                border(~radius=10., ()),
                 color(Color.hex("#ffffff")),
                 background(Color.hexa("#263ac5", 0.9)),
                 margin(20.),


### PR DESCRIPTION
This PR adds some button component styling and a new `BriskStylableText` protocol for dealing with text. All components that use `NSAttributedString` for styling text must conform to this protocol.

It also adds a new `Styles.textStyle` polymorphic set of props that takes care of the common text styling bindings.

`Button` and `TextView` components now conform to `BriskStylableText` protocol and their text styling is factored out into the common `BriskStylableText` binding.

Currently, only default state styling is possible, i.e we don't have highlightStyle yet.

**UPD**: I'm moving highlight and hover styles out of scope of this PR.