### PR TITLE
[WIP] Brisk Async capabilities

### DIFF
--- a/renderer-macos/lib/Brisk.re
+++ b/renderer-macos/lib/Brisk.re
@@ -1,4 +1,4 @@
-module NativeCocoa = {
+module OutputTree = {
   [@deriving (show({with_path: false}), eq)]
   type hostElement = CocoaTypes.view;
 
@@ -34,64 +34,51 @@ module NativeCocoa = {
   let moveNode = (~parent, ~child as _, ~from as _, ~to_ as _) => parent;
 };
 
-include Brisk_reconciler.Make(NativeCocoa);
+include Brisk_reconciler.Make(OutputTree);
 
-module Task = {
-  external runInBackground: (unit => unit) => unit = "ml_runTaskInBackground";
-};
-
-module RunLoop = {
-  let spawn = () => {
-    Printexc.(get_callstack(20) |> raw_backtrace_to_string) |> print_endline;
-  };
-
-  [@noalloc]
-  external getMainFileDescr: unit => [@untagged] int =
-    "ml_getMainFd" "ml_getMainFd";
-
-  let fileDescrOfInt: int => Unix.file_descr = Obj.magic;
-  let intOfFileDescr: Unix.file_descr => int = Obj.magic;
-
+module UI = {
   let rootRef = ref(None);
   let renderedRef = ref(None);
   let heightRef = ref(0.);
 
   let setWindowHeight = height => {
     heightRef := height;
-    NativeCocoa.markAsStale();
+    OutputTree.markAsStale();
   };
 
-  let rec traverseAndApplyLayout =
-          (~height, node: Layout.LayoutSupport.LayoutTypes.node) => {
-    let layout = node.layout;
+  module Layout = {
+    let rec traverseAndApply =
+            (~height, node: Layout.LayoutSupport.LayoutTypes.node) => {
+      let layout = node.layout;
 
-    let nodeTop = float_of_int(layout.top);
-    let nodeHeight = layout.height |> float_of_int;
-    let flippedTop = height -. nodeHeight -. nodeTop;
+      let nodeTop = float_of_int(layout.top);
+      let nodeHeight = layout.height |> float_of_int;
+      let flippedTop = height -. nodeHeight -. nodeTop;
 
-    BriskView.setFrame(
-      node.context,
-      layout.left |> float_of_int,
-      flippedTop,
-      layout.width |> float_of_int,
-      nodeHeight,
-    );
+      BriskView.setFrame(
+        node.context,
+        layout.left |> float_of_int,
+        flippedTop,
+        layout.width |> float_of_int,
+        nodeHeight,
+      );
 
-    node.children
-    |> Array.iter(child => traverseAndApplyLayout(~height=nodeHeight, child));
-  };
+      node.children
+      |> Array.iter(child => traverseAndApply(~height=nodeHeight, child));
+    };
 
-  let performLayout = (~height, root: NativeCocoa.node) => {
-    let node = root.layoutNode;
-    Layout.(
-      layoutNode(
-        node,
-        Flex.FixedEncoding.cssUndefined,
-        Flex.FixedEncoding.cssUndefined,
-        Ltr,
-      )
-    );
-    traverseAndApplyLayout(~height, node);
+    let perform = (~height, root: OutputTree.node) => {
+      let node = root.layoutNode;
+      Layout.(
+        layoutNode(
+          node,
+          Flex.FixedEncoding.cssUndefined,
+          Flex.FixedEncoding.cssUndefined,
+          Ltr,
+        )
+      );
+      traverseAndApply(~height, node);
+    };
   };
 
   let flushPendingUpdates = () =>
@@ -105,81 +92,42 @@ module RunLoop = {
     | _ => ()
     };
 
-  let flushAndLayout = () =>
-    switch (rootRef^) {
-    | Some(root) =>
-      flushPendingUpdates();
-      switch (renderedRef^) {
-      | Some(rendered) =>
-        RenderedElement.executeHostViewUpdates(rendered) |> ignore;
-        performLayout(~height=heightRef^, root);
-      | _ => ()
-      };
+  let executeHostViewUpdatesAndLayout = () =>
+    switch (rootRef^, renderedRef^) {
+    | (Some(root), Some(rendered)) =>
+      RenderedElement.executeHostViewUpdates(rendered) |> ignore;
+      Layout.perform(~height=heightRef^, root);
     | _ => ()
     };
 
   let renderAndMount =
-      (~height, root: NativeCocoa.node, element: syntheticElement) => {
+      (~height, root: OutputTree.node, element: syntheticElement) => {
     let rendered = RenderedElement.render(root, element);
     rootRef := Some(root);
     renderedRef := Some(rendered);
     heightRef := height;
     RenderedElement.executeHostViewUpdates(rendered) |> ignore;
-    performLayout(~height, root);
+    Layout.perform(~height, root);
   };
+};
 
-  [@noalloc]
-  external shouldReleaseRuntime: unit => [@untagged] int =
-    "ml_shouldReleaseRuntime" "ml_shouldReleaseRuntime";
-
-  [@noalloc]
-  external scheduleHostViewUpdateAndLayout: ([@untagged] int) => unit =
-    "ml_scheduleHostViewUpdateAndLayout" "ml_scheduleHostViewUpdateAndLayout";
-
-  let scheduleHostViewUpdateAndLayout = () => {
-    open Lwt.Infix;
-    let (fd_out, fd_in) = Lwt_unix.pipe();
-
-    let fd = fd_in |> Lwt_unix.unix_file_descr |> intOfFileDescr;
-
-    scheduleHostViewUpdateAndLayout(fd);
-
-    Lwt_unix.read(fd_out, Bytes.create(1), 0, 1) >|= (_ => ());
-  };
-
+module RunLoop = {
   let rec run = () => {
-    let fd =
-      getMainFileDescr() |> fileDescrOfInt |> Lwt_unix.of_unix_file_descr;
-    let _ = Lwt_unix.read(fd, Bytes.create(1), 0, 1);
     Lwt.wakeup_paused();
+    /*
+     * iter will return when an fd becomes ready for reading or writing
+     * you can force LWTFakeIOEvenet to start a new iteration
+     */
     Lwt_engine.iter(true);
     Lwt.wakeup_paused();
-
-    if (shouldReleaseRuntime() < 1) {
-      print_endline("ml: shouldReleaseRuntime 0");
-      if (NativeCocoa.isDirty^) {
-        Lwt.Infix.(
-          scheduleHostViewUpdateAndLayout()
-          >|= (() => print_endline("ok"))
-          |> ignore
-        );
-      } else {
-        flushPendingUpdates();
-        run();
-      };
-    } else {
-      print_endline("ml: shouldReleaseRuntime 1");
-      if (NativeCocoa.isDirty^) {
-        Lwt.Infix.(
-          scheduleHostViewUpdateAndLayout()
-          >|= (() => print_endline("ok"))
-          |> ignore
-        );
-      }
+    if (OutputTree.isDirty^) {
+      UI.flushPendingUpdates();
+      OutputTree.isDirty := false;
+      GCD.dispatchSyncMain(UI.executeHostViewUpdatesAndLayout);
     };
+    run();
   };
-
-  /* Callback.register(
-              "Brisk_RunLoop_updateHostViewAndLayout",
-              flushAndLayout); */
+  let spawn = () => {
+    GCD.dispatchAsyncBackground(run);
+  };
 };

--- a/renderer-macos/lib/Brisk_macos.re
+++ b/renderer-macos/lib/Brisk_macos.re
@@ -12,6 +12,7 @@ module Cocoa = {
   module BriskButton = BriskButton;
   module BriskImage = BriskImage;
   module BriskTextView = BriskTextView;
+  module GCD = GCD;
 };
 
 module Layout = Layout;

--- a/renderer-macos/lib/bindings/BriskButton.re
+++ b/renderer-macos/lib/bindings/BriskButton.re
@@ -43,8 +43,6 @@ let setIsBordered = (btn, bordered) => {
   setIsBordered(btn, bordered ? 1 : 0);
 };
 
-external isMain: unit => unit = "ml_is_main";
-
 let make = (~type_=?, ~bezel=?, ~title=?, ~onClick=?, ()) => {
   let btn = make();
 
@@ -67,17 +65,7 @@ let make = (~type_=?, ~bezel=?, ~title=?, ~onClick=?, ()) => {
   | Some(callback) =>
     setCallback(
       btn,
-      () => {
-        /* Main thread */
-        /* Execute the tap handler */
-
-        print_endline("cb");
-        /* Brisk.RunLoop.spawn(); */
-        /* Brisk.RunLoop.flushAndLayout(); */
-        callback();
-        /* Apply all updaets so that we are not one frame behind*/
-        /* "spawn" the worker */
-      },
+      UIEventCallback.make(callback),
     )
   | None => ()
   };

--- a/renderer-macos/lib/bindings/BriskButton.re
+++ b/renderer-macos/lib/bindings/BriskButton.re
@@ -43,6 +43,8 @@ let setIsBordered = (btn, bordered) => {
   setIsBordered(btn, bordered ? 1 : 0);
 };
 
+external isMain: unit => unit = "ml_is_main";
+
 let make = (~type_=?, ~bezel=?, ~title=?, ~onClick=?, ()) => {
   let btn = make();
 
@@ -62,7 +64,21 @@ let make = (~type_=?, ~bezel=?, ~title=?, ~onClick=?, ()) => {
   };
 
   switch (onClick) {
-  | Some(callback) => setCallback(btn, callback)
+  | Some(callback) =>
+    setCallback(
+      btn,
+      () => {
+        /* Main thread */
+        /* Execute the tap handler */
+
+        print_endline("cb");
+        /* Brisk.RunLoop.spawn(); */
+        /* Brisk.RunLoop.flushAndLayout(); */
+        callback();
+        /* Apply all updaets so that we are not one frame behind*/
+        /* "spawn" the worker */
+      },
+    )
   | None => ()
   };
 

--- a/renderer-macos/lib/bindings/GCD.re
+++ b/renderer-macos/lib/bindings/GCD.re
@@ -1,0 +1,3 @@
+  external dispatchAsyncBackground: (unit => unit) => unit = "ml_dispatchAsyncBackground";
+  external dispatchSyncMain: (unit => unit) => unit = "ml_dispatchSyncMain";
+  external printIsMain: unit => unit = "ml_printIsMain";

--- a/renderer-macos/lib/bindings/LwtFakeIOEvent.re
+++ b/renderer-macos/lib/bindings/LwtFakeIOEvent.re
@@ -1,0 +1,12 @@
+let (fd_out, fd_in) = Unix.pipe();
+
+let bytes_write = Bytes.create(1);
+let perform = () => Unix.write(fd_in, bytes_write, 0, 1) |> ignore;
+
+let () = {
+  let bytes_read = Bytes.create(1);
+  Lwt_engine.on_readable(fd_out, _ =>
+    Unix.read(fd_out, bytes_read, 0, 1) |> ignore
+  )
+  |> ignore;
+};

--- a/renderer-macos/lib/bindings/UIEventCallback.re
+++ b/renderer-macos/lib/bindings/UIEventCallback.re
@@ -1,0 +1,6 @@
+let make = (callback, ()) => {
+  callback();
+  Brisk.UI.flushPendingUpdates();
+  Brisk.UI.executeHostViewUpdatesAndLayout();
+  LwtFakeIOEvent.perform();
+}

--- a/renderer-macos/lib/dune
+++ b/renderer-macos/lib/dune
@@ -6,7 +6,7 @@
  (name brisk_macos)
  (public_name brisk-macos)
  (synopsis "Cocoa renderer and bindings")
- (libraries brisk-reconciler brisk-renderer)
+ (libraries brisk-reconciler brisk-renderer lwt.unix)
  (install_c_headers BriskCocoa
                     BriskApplicationDelegate
                     BriskWindowDelegate

--- a/renderer-macos/lib/dune
+++ b/renderer-macos/lib/dune
@@ -21,6 +21,7 @@
           BriskTextView
           BriskImage
           BriskButton
+          GCD
           )
  (c_flags (:standard
   (-Wextra -Wall -Werror -O -g -std=c99 -pedantic-errors -Wsign-compare -Wshadow)

--- a/renderer-macos/lib/stubs/BriskApplicationDelegate.c
+++ b/renderer-macos/lib/stubs/BriskApplicationDelegate.c
@@ -3,39 +3,36 @@
 
 @implementation BriskApplicationDelegate
 
-- (void)callOCamlFunctionNamed:(const char *)name
-              memoizeToPointer:(value **)staticPointer {
+- (value *)memoizeOCamlFunctionNamed:(const char *)name
+              toPointer:(value **)staticPointer {
   if (*staticPointer == NULL) {
     *staticPointer = caml_named_value(name);
   }
-
-  if (*staticPointer != NULL) {
-    caml_callback(**staticPointer, Val_unit);
-  }
+  return *staticPointer;
 }
 
 - (void)applicationWillTerminate:(NSNotification *)__unused not{
   static value *closure_f = NULL;
-  brisk_caml_call(^{
-    [self callOCamlFunctionNamed:"NSAppDelegate.applicationWillTerminate"
-                memoizeToPointer:&closure_f];
-  });
+  closure_f = [self memoizeOCamlFunctionNamed:"NSAppDelegate.applicationWillTerminate"
+                toPointer:&closure_f];
+
+  brisk_caml_call(*closure_f);
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification *)__unused not{
   static value *closure_f = NULL;
-  brisk_caml_call(^{
-    [self callOCamlFunctionNamed:"NSAppDelegate.applicationWillFinishLaunching"
-                memoizeToPointer:&closure_f];
-  });
+  closure_f = [self memoizeOCamlFunctionNamed:"NSAppDelegate.applicationWillFinishLaunching"
+                toPointer:&closure_f];
+
+  brisk_caml_call(*closure_f);
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)__unused not{
   static value *closure_f = NULL;
-  brisk_caml_call(^{
-    [self callOCamlFunctionNamed:"NSAppDelegate.applicationDidFinishLaunching"
-                memoizeToPointer:&closure_f];
-  });
+  closure_f = [self memoizeOCamlFunctionNamed:"NSAppDelegate.applicationDidFinishLaunching"
+                toPointer:&closure_f];
+
+  brisk_caml_call(*closure_f);
 }
 
 @end

--- a/renderer-macos/lib/stubs/BriskButton.c
+++ b/renderer-macos/lib/stubs/BriskButton.c
@@ -9,22 +9,6 @@
 
 @end
 
-// - (void)onTap:(id)sender {
-//   setWantsOCamlRuntime();
-//   /*
-//   Set the flag to release runtime
-//   Send 1 bit to the descriptor (research)
-//   */
-
-//   brisk_caml_callback(whatever);
-//   /*
-//   Call the handler
-//   Run flushPendingUpdates (sync)
-//   v2 - only flush the updates that have been added here
-//   Restart LWT loop on bg
-//   */
-// }
-
 @implementation BriskButton
 
 @synthesize attributedString;
@@ -64,11 +48,9 @@
 }
 
 - (void)performCallback {
-  brisk_setNeedsRuntime();
-  brisk_caml_call(^{
-    caml_callback(self._callback, Val_unit);
-  });
+  brisk_caml_call(self._callback);
 }
+
 @end
 
 BriskButton *ml_BriskButton_make() {

--- a/renderer-macos/lib/stubs/BriskButton.c
+++ b/renderer-macos/lib/stubs/BriskButton.c
@@ -9,6 +9,22 @@
 
 @end
 
+// - (void)onTap:(id)sender {
+//   setWantsOCamlRuntime();
+//   /*
+//   Set the flag to release runtime
+//   Send 1 bit to the descriptor (research)
+//   */
+
+//   brisk_caml_callback(whatever);
+//   /*
+//   Call the handler
+//   Run flushPendingUpdates (sync)
+//   v2 - only flush the updates that have been added here
+//   Restart LWT loop on bg
+//   */
+// }
+
 @implementation BriskButton
 
 @synthesize attributedString;
@@ -48,6 +64,7 @@
 }
 
 - (void)performCallback {
+  brisk_setNeedsRuntime();
   brisk_caml_call(^{
     caml_callback(self._callback, Val_unit);
   });

--- a/renderer-macos/lib/stubs/BriskCocoa.c
+++ b/renderer-macos/lib/stubs/BriskCocoa.c
@@ -5,81 +5,16 @@
 #import <caml/unixsupport.h>
 
 NSMutableSet *retainedViews;
-int mainNeedsOCaml;
-int fds[2];
 
 void brisk_init() {
   retainedViews = [NSMutableSet new];
-  mainNeedsOCaml = 0;
-  pipe(fds);
 }
 
-void brisk_caml_call(void (^block)()) {
-  // This should only be called when we call from outside of OCaml I suppose
+void brisk_caml_call(value f) {
   caml_c_thread_register();
   caml_acquire_runtime_system();
-  block();
+  caml_callback(f, Val_unit);
   caml_release_runtime_system();
-
-  mainNeedsOCaml = 0;
-}
-
-intnat ml_shouldReleaseRuntime() { return mainNeedsOCaml; }
-
-intnat ml_getMainFd() { return (intnat)fds[0]; }
-
-void brisk_setNeedsRuntime() {
-  printf("brisk_setNeedsRuntime\n");
-  mainNeedsOCaml = 1;
-  char buffer = 'a';
-  write(fds[1], &buffer, 1);
-}
-
-void ml_runTaskInBackground(value taskFn_v) {
-  CAMLparam1(taskFn_v);
-
-  value taskFn = taskFn_v;
-
-  printf("ml_runTaskInBackground\n");
-  mainNeedsOCaml = NO;
-  caml_register_global_root(&taskFn);
-
-  dispatch_queue_t global =
-      dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-  dispatch_async(global, ^{
-    brisk_caml_call(^{
-      caml_callback(taskFn, Val_unit);
-    });
-    // caml_remove_global_root(&taskFn);
-  });
-}
-
-void flush_and_layout_sync() {
-  // caml_callback(*caml_named_value("Brisk_RunLoop_updateHostViewAndLayout"),
-  //               Val_unit);
-}
-
-void ml_scheduleHostViewUpdateAndLayout(intnat fd) {
-  printf("ml_scheduleHostViewUpdateAndLayout\n");
-  caml_release_runtime_system();
-  printf("dafuq?");
-  dispatch_async(dispatch_get_main_queue(), ^{
-    brisk_caml_call(^{
-      flush_and_layout_sync();
-      char buffer = 'a';
-      printf("fd %ld", fd);
-      write(fd, &buffer, 1);
-    });
-  });
-}
-
-void ml_is_main() { printf("isMainThread: %i\n", [NSThread isMainThread]); }
-
-void brisk_caml_call_and_flush(void (^block)()) {
-  brisk_caml_call(^{
-    block();
-    flush_and_layout_sync();
-  });
 }
 
 void retainView(NSView *view) { [retainedViews addObject:view]; }

--- a/renderer-macos/lib/stubs/BriskCocoa.c
+++ b/renderer-macos/lib/stubs/BriskCocoa.c
@@ -2,67 +2,78 @@
 #import "BriskApplicationDelegate.h"
 #import "BriskWindowDelegate.h"
 #import <caml/threads.h>
-
-dispatch_semaphore_t caml_thread_sema;
+#import <caml/unixsupport.h>
 
 NSMutableSet *retainedViews;
+int mainNeedsOCaml;
+int fds[2];
 
 void brisk_init() {
   retainedViews = [NSMutableSet new];
-  caml_thread_sema = dispatch_semaphore_create(1);
-}
-
-void ml_isMain() { NSLog(@"%i", [NSThread isMainThread]); }
-
-CAMLprim void run_lwt_iter_if_needed() {
-  /*
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
-  ^{ brisk_caml_call(^{ intnat should_schedule =
-  caml_callback(*caml_named_value("Brisk_lwt_iter"), Val_unit); if
-  (should_schedule == 1) { ml_lwt_iter();
-      }
-    });
-    ml_lwt_iter();
-  });
-  */
+  mainNeedsOCaml = 0;
+  pipe(fds);
 }
 
 void brisk_caml_call(void (^block)()) {
-  dispatch_semaphore_wait(caml_thread_sema, DISPATCH_TIME_FOREVER);
   // This should only be called when we call from outside of OCaml I suppose
   caml_c_thread_register();
   caml_acquire_runtime_system();
   block();
   caml_release_runtime_system();
-  dispatch_semaphore_signal(caml_thread_sema);
-  run_lwt_iter_if_needed();
+
+  mainNeedsOCaml = 0;
 }
 
-CAMLprim void ml_lwt_iter() {
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
-                 ^{
-                   brisk_caml_call(^{
-                     /*intnat should_schedule = */ caml_callback(
-                         *caml_named_value("Brisk_lwt_iter"), Val_unit);
-                     // if (should_schedule == 1) {
-                     // }
-                   });
-                   sleep(2);
-                   ml_lwt_iter();
-                 });
+intnat ml_shouldReleaseRuntime() { return mainNeedsOCaml; }
+
+intnat ml_getMainFd() { return (intnat)fds[0]; }
+
+void brisk_setNeedsRuntime() {
+  printf("brisk_setNeedsRuntime\n");
+  mainNeedsOCaml = 1;
+  char buffer = 'a';
+  write(fds[1], &buffer, 1);
+}
+
+void ml_runTaskInBackground(value taskFn_v) {
+  CAMLparam1(taskFn_v);
+
+  value taskFn = taskFn_v;
+
+  printf("ml_runTaskInBackground\n");
+  mainNeedsOCaml = NO;
+  caml_register_global_root(&taskFn);
+
+  dispatch_queue_t global =
+      dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+  dispatch_async(global, ^{
+    brisk_caml_call(^{
+      caml_callback(taskFn, Val_unit);
+    });
+    // caml_remove_global_root(&taskFn);
+  });
 }
 
 void flush_and_layout_sync() {
-  caml_callback(*caml_named_value("Brisk_flush_layout"), Val_unit);
+  // caml_callback(*caml_named_value("Brisk_RunLoop_updateHostViewAndLayout"),
+  //               Val_unit);
 }
 
-void ml_schedule_layout_flush() {
+void ml_scheduleHostViewUpdateAndLayout(intnat fd) {
+  printf("ml_scheduleHostViewUpdateAndLayout\n");
+  caml_release_runtime_system();
+  printf("dafuq?");
   dispatch_async(dispatch_get_main_queue(), ^{
     brisk_caml_call(^{
       flush_and_layout_sync();
+      char buffer = 'a';
+      printf("fd %ld", fd);
+      write(fd, &buffer, 1);
     });
   });
 }
+
+void ml_is_main() { printf("isMainThread: %i\n", [NSThread isMainThread]); }
 
 void brisk_caml_call_and_flush(void (^block)()) {
   brisk_caml_call(^{

--- a/renderer-macos/lib/stubs/BriskCocoa.h
+++ b/renderer-macos/lib/stubs/BriskCocoa.h
@@ -7,6 +7,8 @@
 // Enter OCaml runtime and obtain the semaphore
 void brisk_caml_call(void (^block)());
 
+void brisk_setNeedsRuntime();
+
 // Enter OCaml runtime and obtain the semaphore, after that run flush
 // This could be potentially implemented on the OCaml side. Not sure.
 void brisk_caml_call_and_flush(void (^block)());

--- a/renderer-macos/lib/stubs/BriskCocoa.h
+++ b/renderer-macos/lib/stubs/BriskCocoa.h
@@ -5,13 +5,7 @@
 #import <caml/memory.h>
 
 // Enter OCaml runtime and obtain the semaphore
-void brisk_caml_call(void (^block)());
-
-void brisk_setNeedsRuntime();
-
-// Enter OCaml runtime and obtain the semaphore, after that run flush
-// This could be potentially implemented on the OCaml side. Not sure.
-void brisk_caml_call_and_flush(void (^block)());
+void brisk_caml_call(value callback);
 
 // Call during app launch before any OCaml code is called
 void brisk_init();

--- a/renderer-macos/lib/stubs/BriskWindowDelegate.c
+++ b/renderer-macos/lib/stubs/BriskWindowDelegate.c
@@ -4,18 +4,16 @@
 
 - (void)windowDidResize:(NSNotification *)__unused aNotification {
   if (self.didResizeCallback) {
-    brisk_caml_call_and_flush(^{
-      caml_callback(self.didResizeCallback, Val_unit);
-    });
+    brisk_caml_call(self.didResizeCallback);
   }
 }
 
 - (void)setOnWindowDidResize:(value)callback {
   if (self.didResizeCallback) {
     value prevCallback = self.didResizeCallback;
-    caml_remove_global_root(&prevCallback);
+    caml_modify_generational_global_root(&prevCallback, callback);
   }
-  caml_register_global_root(&callback);
+  caml_register_generational_global_root(&callback);
   self.didResizeCallback = callback;
 }
 

--- a/renderer-macos/lib/stubs/GCD.c
+++ b/renderer-macos/lib/stubs/GCD.c
@@ -1,0 +1,33 @@
+#import "BriskCocoa.h"
+#import <caml/threads.h>
+#import <caml/unixsupport.h>
+
+void ml_printIsMain() { printf("isMainThread: %i\n", [NSThread isMainThread]); }
+
+void ml_dispatchAsyncBackground(value taskFn_v) {
+  CAMLparam1(taskFn_v);
+  value taskFn = taskFn_v;
+  caml_register_global_root(&taskFn);
+
+  dispatch_queue_t global =
+      dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+  dispatch_async(global, ^{
+    brisk_caml_call(taskFn);
+    caml_remove_global_root((value *)&taskFn);
+  });
+}
+
+void ml_dispatchSyncMain(value taskFn_v) {
+  CAMLparam1(taskFn_v);
+  value taskFn = taskFn_v;
+  caml_register_global_root(&taskFn);
+
+  caml_release_runtime_system();
+
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    brisk_caml_call(taskFn);
+    caml_remove_global_root((value *)&taskFn);
+  });
+
+  caml_acquire_runtime_system();
+}

--- a/tester-macos/app/Makefile
+++ b/tester-macos/app/Makefile
@@ -1,4 +1,4 @@
-.phone: bootstrap
+.PHONY: bootstrap run build exec
 
 CONFIGURATION="Debug"
 SCHEME="BriskMac"

--- a/tester-macos/bin/app.re
+++ b/tester-macos/bin/app.re
@@ -85,7 +85,7 @@ module Component = {
               background(Color.hex("#263ac5")),
               align(`Center),
             ]
-            title="You're gonna have to wait a bit"
+            title="You're gonna have to wait 1 second"
             callback={() =>
               Lwt.Infix.(
                 ignore(
@@ -122,7 +122,7 @@ let () = {
           ~style=[width(window#contentWidth), height(window#contentHeight)],
           view,
         );
-      {Brisk.NativeCocoa.view, layoutNode};
+      {Brisk.OutputTree.view, layoutNode};
     };
 
     window#center;
@@ -131,29 +131,17 @@ let () = {
     window#setContentView(root.view);
 
     window#windowDidResize(_ =>
-      Brisk.RunLoop.setWindowHeight(window#contentHeight)
+      Brisk.UI.setWindowHeight(window#contentHeight)
     );
 
-    Brisk.RunLoop.renderAndMount(
+    Brisk.UI.renderAndMount(
       ~height=window#contentHeight,
       root,
       Brisk.element(<Component />),
     );
 
-    Brisk.Task.runInBackground(() => {
-      print_endline("running task in bg");
-      Brisk.RunLoop.run();
-    });
+    Brisk.RunLoop.spawn();
   });
 
   Application.run();
 };
-
-/*
-
- 1.main
-   - Create a promise
-    Blocks, waits on a byte from main
- 2.bg
-  - Create another
-  */

--- a/tester-macos/bin/dune
+++ b/tester-macos/bin/dune
@@ -1,6 +1,6 @@
 (executable
  (name app)
- (libraries brisk-macos osx-cf.lwt lwt.unix)
+ (libraries brisk-macos)
  (modes object))
 
 (install

--- a/tester-macos/esy.json
+++ b/tester-macos/esy.json
@@ -2,7 +2,7 @@
   "name": "@brisk/tester-macos",
   "version": "0.1.0",
   "esy": {
-    "build": ["dune build @install --only-packages brisk-tester-macos --root ."]
+    "build": ["dune build -p brisk-tester-macos"]
   },
   "dependencies": {
     "@esy-ocaml/libffi": "*",


### PR DESCRIPTION
This PR adds a two threaded communication in brisk applications:

1). UI happens on the main thread
2). Logic happens on the background thread

![brisk-async](https://user-images.githubusercontent.com/9691/51802987-b3c8d900-2260-11e9-949f-b9420fcedbcb.gif)

So far, this only sleeps for 1 second before changing state, but we need to add some examples of HTTP requests. This also closes #36 and gives a way to implement #33.

Huge thanks to @aantron for helping us understand how `Lwt` works internally and making this possible.