### PR TITLE
UI: EffectView component

### DIFF
--- a/examples/components-macos/bin/app.re
+++ b/examples/components-macos/bin/app.re
@@ -12,8 +12,7 @@ module Component = {
         <EffectView
           blendingMode=EffectView.BlendingMode.behindWindow
           style=[
-            width(100.),
-            height(100.),
+            position(~top=0., ~left=0., ~right=0., ~bottom=0., `Absolute),
           ]>
           <Button
             style=[width(100.), height(100.), align(`Center)]

--- a/examples/components-macos/bin/app.re
+++ b/examples/components-macos/bin/app.re
@@ -10,9 +10,9 @@ module Component = {
       switch (state) {
       | Some(code) =>
         <EffectView
-          style=[
+          style=EffectView.[
             position(~top=0., ~left=0., ~right=0., ~bottom=0., `Absolute),
-            `BlendingMode(`BehindWindow),
+            blendingMode(`BehindWindow),
           ]>
           <Button
             style=[width(100.), height(100.), align(`Center)]

--- a/examples/components-macos/bin/app.re
+++ b/examples/components-macos/bin/app.re
@@ -9,12 +9,11 @@ module Component = {
         Brisk.Hooks.state(None, slots);
       switch (state) {
       | Some(code) =>
-        <View
+        <EffectView
+          blendingMode=EffectView.BlendingMode.behindWindow
           style=[
             width(100.),
             height(100.),
-            background(Color.rgb(0, 255, 0)),
-            border(~width=1., ~color=Color.rgb(0, 0, 255), ()),
           ]>
           <Button
             style=[width(100.), height(100.), align(`Center)]
@@ -26,7 +25,7 @@ module Component = {
             title="Cell two"
             callback={() => setState(None)}
           />
-        </View>
+        </EffectView>
       | None =>
         <ScrollView
           style=[
@@ -128,8 +127,9 @@ let () = {
     let window = Window.makeWithContentRect(0., 0., 680., 468.);
 
     let root = {
-      let view = BriskView.make();
       open Brisk.Layout;
+      let view = BriskEffectView.make();
+
       let layoutNode =
         Node.make(
           ~style=[

--- a/examples/components-macos/bin/app.re
+++ b/examples/components-macos/bin/app.re
@@ -10,9 +10,9 @@ module Component = {
       switch (state) {
       | Some(code) =>
         <EffectView
-          blendingMode=EffectView.BlendingMode.behindWindow
           style=[
             position(~top=0., ~left=0., ~right=0., ~bottom=0., `Absolute),
+            `BlendingMode(`BehindWindow),
           ]>
           <Button
             style=[width(100.), height(100.), align(`Center)]
@@ -127,7 +127,7 @@ let () = {
 
     let root = {
       open Brisk.Layout;
-      let view = BriskEffectView.make();
+      let view = BriskView.make();
 
       let layoutNode =
         Node.make(

--- a/renderer-macos/lib/Brisk_macos.re
+++ b/renderer-macos/lib/Brisk_macos.re
@@ -13,6 +13,8 @@ module Cocoa = {
   module BriskImage = BriskImage;
   module BriskTextView = BriskTextView;
   module GCD = GCD;
+
+  module BriskEffectView = BriskEffectView;
 };
 
 /* Components */
@@ -21,3 +23,4 @@ module ScrollView = ScrollView;
 module Text = Text;
 module Image = Image;
 module Button = Button;
+module EffectView = EffectView;

--- a/renderer-macos/lib/bindings/BriskEffectView.re
+++ b/renderer-macos/lib/bindings/BriskEffectView.re
@@ -1,90 +1,111 @@
-
 module Material = {
   type t;
+
   external titlebar: unit => t =
     "ml_getNSVisualEffectMaterialTitlebar_bc"
     "ml_getNSVisualEffectMaterialTitlebar";
-  let titlebar = titlebar();
+
   external selection: unit => t =
     "ml_getNSVisualEffectMaterialSelection_bc"
     "ml_getNSVisualEffectMaterialSelection";
-  let selection = selection();
+
   external menu: unit => t =
     "ml_getNSVisualEffectMaterialMenu_bc" "ml_getNSVisualEffectMaterialMenu";
-  let menu = menu();
+
   external popover: unit => t =
     "ml_getNSVisualEffectMaterialPopover_bc"
     "ml_getNSVisualEffectMaterialPopover";
-  let popover = popover();
+
   external sidebar: unit => t =
     "ml_getNSVisualEffectMaterialSidebar_bc"
     "ml_getNSVisualEffectMaterialSidebar";
-  let sidebar = sidebar();
-  /*
-  external headerView: unit => t =
-    "ml_getNSVisualEffectMaterialHeaderView_bc"
-    "ml_getNSVisualEffectMaterialHeaderView";
-  let headerView = headerView();
-  external sheet: unit => t =
-    "ml_getNSVisualEffectMaterialSheet_bc" "ml_getNSVisualEffectMaterialSheet";
-  let sheet = sheet();
-  external windowBackground: unit => t =
-    "ml_getNSVisualEffectMaterialWindowBackground_bc"
-    "ml_getNSVisualEffectMaterialWindowBackground";
-  let windowBackground = windowBackground();
-  external hUDWindow: unit => t =
-    "ml_getNSVisualEffectMaterialHUDWindow_bc"
-    "ml_getNSVisualEffectMaterialHUDWindow";
-  let hUDWindow = hUDWindow();
-  external fullScreenUI: unit => t =
-    "ml_getNSVisualEffectMaterialFullScreenUI_bc"
-    "ml_getNSVisualEffectMaterialFullScreenUI";
-  let fullScreenUI = fullScreenUI();
-  external toolTip: unit => t =
-    "ml_getNSVisualEffectMaterialToolTip_bc"
-    "ml_getNSVisualEffectMaterialToolTip";
-  let toolTip = toolTip();
-  external contentBackground: unit => t =
-    "ml_getNSVisualEffectMaterialContentBackground_bc"
-    "ml_getNSVisualEffectMaterialContentBackground";
-  let contentBackground = contentBackground();
-  external underWindowBackground: unit => t =
-    "ml_getNSVisualEffectMaterialUnderWindowBackground_bc"
-    "ml_getNSVisualEffectMaterialUnderWindowBackground";
-  let underWindowBackground = underWindowBackground();
-  external pageBackground: unit => t =
-    "ml_getNSVisualEffectMaterialPageBackground_bc"
-    "ml_getNSVisualEffectMaterialPageBackground";
-  let pageBackground = pageBackground();
-  external appeareanceBased: unit => t =
-    "ml_getNSVisualEffectMaterialAppeareanceBased_bc"
-    "ml_getNSVisualEffectMaterialAppeareanceBased";
-  let appeareanceBased = appeareanceBased();
-  */
 };
 
 module BlendingMode = {
   type t;
+
   external behindWindow: unit => t =
     "ml_getNSVisualEffectBlendingModeBehindWindow_bc"
     "ml_getNSVisualEffectBlendingModeBehindWindow";
-  let behindWindow = behindWindow();
+
   external withinWindow: unit => t =
     "ml_getNSVisualEffectBlendingModeWithinWindow_bc"
     "ml_getNSVisualEffectBlendingModeWithinWindow";
-  let withinWindow = withinWindow();
 };
 
-type backgroundStyle =
-  | Raised
-  | Lowered;
+module EffectState = {
+  type t;
 
-type visualEffectState =
-  | FollowsWindowActiveState
-  | Active
-  | Inactive;
+  external followsWindowActiveState: unit => t =
+    "ml_getNSVisualEffectStateFollowsWindowActiveState_bc"
+    "ml_getNSVisualEffectStateFollowsWindowActiveState";
+
+  external active: unit => t =
+    "ml_getNSVisualEffectStateActive_bc" "ml_getNSVisualEffectStateActive";
+
+  external inactive: unit => t =
+    "ml_getNSVisualEffectStateInactive_bc" "ml_getNSVisualEffectStateInactive";
+};
+
+type material = [ | `Titlebar | `Selection | `Menu | `Popover | `Sidebar];
+type blendingMode = [ | `BehindWindow | `WithinWindow];
+type effectState = [ | `FollowsWindowActiveState | `Active | `Inactive];
+
+type style = [
+  | `Material(material)
+  | `BlendingMode(blendingMode)
+  | `Emphasized(bool)
+  | `EffectState(effectState)
+];
 
 type t = CocoaTypes.view;
+
 [@noalloc] external make: unit => t = "ml_NSVisualEffectView_make";
-[@noalloc] external setMaterial: (CocoaTypes.view, Material.t) => unit = "ml_NSVisualEffectView_setMaterial";
-[@noalloc] external setBlendingMode: (CocoaTypes.view, BlendingMode.t) => unit = "ml_NSVisualEffectView_setBlendingMode";
+
+[@noalloc]
+external setMaterial: (CocoaTypes.view, Material.t) => unit =
+  "ml_NSVisualEffectView_setMaterial";
+[@noalloc]
+external setBlendingMode: (CocoaTypes.view, BlendingMode.t) => unit =
+  "ml_NSVisualEffectView_setBlendingMode";
+[@noalloc]
+external setEmphasized: (CocoaTypes.view, [@untagged] int) => unit =
+  "ml_NSVisualEffectView_setEmphasized_bc"
+  "ml_NSVisualEffectView_setEmphasized";
+[@noalloc]
+external setEffectState: (CocoaTypes.view, EffectState.t) => unit =
+  "ml_NSVisualEffectView_setEffectState";
+
+let setStyle = (view, attribute: [> style]) =>
+  switch (attribute) {
+  | `Material(material) =>
+    (
+      switch (material) {
+      | `Titlebar => Material.titlebar()
+      | `Selection => Material.selection()
+      | `Menu => Material.menu()
+      | `Popover => Material.popover()
+      | `Sidebar => Material.sidebar()
+      }
+    )
+    |> setMaterial(view)
+  | `BlendingMode(blendingMode) =>
+    (
+      switch (blendingMode) {
+      | `BehindWindow => BlendingMode.behindWindow()
+      | `WithinWindow => BlendingMode.withinWindow()
+      }
+    )
+    |> setBlendingMode(view)
+  | `Emphasized(emphasized) => setEmphasized(view, emphasized ? 1 : 0)
+  | `EffectState(effectState) =>
+    (
+      switch (effectState) {
+      | `FollowsWindowActiveState => EffectState.followsWindowActiveState()
+      | `Active => EffectState.active()
+      | `Inactive => EffectState.inactive()
+      }
+    )
+    |> setEffectState(view)
+  | _ => ()
+  };

--- a/renderer-macos/lib/bindings/BriskEffectView.re
+++ b/renderer-macos/lib/bindings/BriskEffectView.re
@@ -1,0 +1,90 @@
+
+module Material = {
+  type t;
+  external titlebar: unit => t =
+    "ml_getNSVisualEffectMaterialTitlebar_bc"
+    "ml_getNSVisualEffectMaterialTitlebar";
+  let titlebar = titlebar();
+  external selection: unit => t =
+    "ml_getNSVisualEffectMaterialSelection_bc"
+    "ml_getNSVisualEffectMaterialSelection";
+  let selection = selection();
+  external menu: unit => t =
+    "ml_getNSVisualEffectMaterialMenu_bc" "ml_getNSVisualEffectMaterialMenu";
+  let menu = menu();
+  external popover: unit => t =
+    "ml_getNSVisualEffectMaterialPopover_bc"
+    "ml_getNSVisualEffectMaterialPopover";
+  let popover = popover();
+  external sidebar: unit => t =
+    "ml_getNSVisualEffectMaterialSidebar_bc"
+    "ml_getNSVisualEffectMaterialSidebar";
+  let sidebar = sidebar();
+  /*
+  external headerView: unit => t =
+    "ml_getNSVisualEffectMaterialHeaderView_bc"
+    "ml_getNSVisualEffectMaterialHeaderView";
+  let headerView = headerView();
+  external sheet: unit => t =
+    "ml_getNSVisualEffectMaterialSheet_bc" "ml_getNSVisualEffectMaterialSheet";
+  let sheet = sheet();
+  external windowBackground: unit => t =
+    "ml_getNSVisualEffectMaterialWindowBackground_bc"
+    "ml_getNSVisualEffectMaterialWindowBackground";
+  let windowBackground = windowBackground();
+  external hUDWindow: unit => t =
+    "ml_getNSVisualEffectMaterialHUDWindow_bc"
+    "ml_getNSVisualEffectMaterialHUDWindow";
+  let hUDWindow = hUDWindow();
+  external fullScreenUI: unit => t =
+    "ml_getNSVisualEffectMaterialFullScreenUI_bc"
+    "ml_getNSVisualEffectMaterialFullScreenUI";
+  let fullScreenUI = fullScreenUI();
+  external toolTip: unit => t =
+    "ml_getNSVisualEffectMaterialToolTip_bc"
+    "ml_getNSVisualEffectMaterialToolTip";
+  let toolTip = toolTip();
+  external contentBackground: unit => t =
+    "ml_getNSVisualEffectMaterialContentBackground_bc"
+    "ml_getNSVisualEffectMaterialContentBackground";
+  let contentBackground = contentBackground();
+  external underWindowBackground: unit => t =
+    "ml_getNSVisualEffectMaterialUnderWindowBackground_bc"
+    "ml_getNSVisualEffectMaterialUnderWindowBackground";
+  let underWindowBackground = underWindowBackground();
+  external pageBackground: unit => t =
+    "ml_getNSVisualEffectMaterialPageBackground_bc"
+    "ml_getNSVisualEffectMaterialPageBackground";
+  let pageBackground = pageBackground();
+  external appeareanceBased: unit => t =
+    "ml_getNSVisualEffectMaterialAppeareanceBased_bc"
+    "ml_getNSVisualEffectMaterialAppeareanceBased";
+  let appeareanceBased = appeareanceBased();
+  */
+};
+
+module BlendingMode = {
+  type t;
+  external behindWindow: unit => t =
+    "ml_getNSVisualEffectBlendingModeBehindWindow_bc"
+    "ml_getNSVisualEffectBlendingModeBehindWindow";
+  let behindWindow = behindWindow();
+  external withinWindow: unit => t =
+    "ml_getNSVisualEffectBlendingModeWithinWindow_bc"
+    "ml_getNSVisualEffectBlendingModeWithinWindow";
+  let wihthinWindow = withinWindow();
+};
+
+type backgroundStyle =
+  | Raised
+  | Lowered;
+
+type visualEffectState =
+  | FollowsWindowActiveState
+  | Active
+  | Inactive;
+
+type t = CocoaTypes.view;
+[@noalloc] external make: unit => t = "ml_NSVisualEffectView_make";
+[@noalloc] external setMaterial: (CocoaTypes.view, Material.t) => unit = "ml_NSVisualEffectView_setMaterial";
+[@noalloc] external setBlendingMode: (CocoaTypes.view, BlendingMode.t) => unit = "ml_NSVisualEffectView_setBlendingMode";

--- a/renderer-macos/lib/bindings/BriskEffectView.re
+++ b/renderer-macos/lib/bindings/BriskEffectView.re
@@ -72,7 +72,7 @@ module BlendingMode = {
   external withinWindow: unit => t =
     "ml_getNSVisualEffectBlendingModeWithinWindow_bc"
     "ml_getNSVisualEffectBlendingModeWithinWindow";
-  let wihthinWindow = withinWindow();
+  let withinWindow = withinWindow();
 };
 
 type backgroundStyle =

--- a/renderer-macos/lib/components/EffectView.re
+++ b/renderer-macos/lib/components/EffectView.re
@@ -1,0 +1,44 @@
+open Brisk;
+open Layout;
+
+module Material = BriskEffectView.Material;
+module BlendingMode = BriskEffectView.BlendingMode;
+
+type attr = [ Layout.style | Styles.viewStyle];
+
+type style = list(attr);
+
+let component = nativeComponent("View");
+
+let make = (~style: style=[], ~blendingMode, ~material, children) =>
+  component((_: Hooks.empty) =>
+    {
+      make: () => {
+        let view = BriskEffectView.make();
+        {view, layoutNode: makeLayoutNode(~style, view)};
+      },
+      configureInstance: (~isFirstRender as _, {view} as node) => {
+        switch (blendingMode) {
+        | Some(blendingMode) =>
+          BriskEffectView.setBlendingMode(view, blendingMode)
+        | _ => ()
+        };
+        switch (material) {
+        | Some(material) => BriskEffectView.setMaterial(view, material)
+        | _ => ()
+        };
+        style
+        |> List.iter(attr =>
+             switch (attr) {
+             | #Styles.viewStyle => Styles.setViewStyle(view, attr)
+             | #Layout.style => ()
+             }
+           );
+        node;
+      },
+      children,
+    }
+  );
+
+let createElement = (~style=[], ~children, ~blendingMode=?, ~material=?, ()) =>
+  element(make(~style, ~blendingMode, ~material, listToElement(children)));

--- a/renderer-macos/lib/components/EffectView.re
+++ b/renderer-macos/lib/components/EffectView.re
@@ -1,5 +1,4 @@
 open Brisk;
-open Layout;
 
 module Material = BriskEffectView.Material;
 module BlendingMode = BriskEffectView.BlendingMode;
@@ -15,7 +14,7 @@ let make = (~style: style=[], ~blendingMode, ~material, children) =>
     {
       make: () => {
         let view = BriskEffectView.make();
-        {view, layoutNode: makeLayoutNode(~style, view)};
+        {view, layoutNode: Layout.Node.make(~style, view)};
       },
       configureInstance: (~isFirstRender as _, {view} as node) => {
         switch (blendingMode) {

--- a/renderer-macos/lib/components/EffectView.re
+++ b/renderer-macos/lib/components/EffectView.re
@@ -1,11 +1,13 @@
 open Brisk;
 
-module Material = BriskEffectView.Material;
-module BlendingMode = BriskEffectView.BlendingMode;
-
 type attribute = [ Layout.style | BriskEffectView.style];
 
 type style = list(attribute);
+
+let material = material => `Material(material);
+let blendingMode = blendingMode => `BlendingMode(blendingMode);
+let emphasized = emphasized => `Emphasized(emphasized);
+let effectState = effectState => `EffectState(effectState);
 
 let component = nativeComponent("EffectView");
 

--- a/renderer-macos/lib/components/EffectView.re
+++ b/renderer-macos/lib/components/EffectView.re
@@ -3,13 +3,13 @@ open Brisk;
 module Material = BriskEffectView.Material;
 module BlendingMode = BriskEffectView.BlendingMode;
 
-type attr = [ Layout.style | Styles.viewStyle];
+type attribute = [ Layout.style | BriskEffectView.style];
 
-type style = list(attr);
+type style = list(attribute);
 
-let component = nativeComponent("View");
+let component = nativeComponent("EffectView");
 
-let make = (~style: style=[], ~blendingMode, ~material, children) =>
+let make = (~style: style=[], children) =>
   component((_: Hooks.empty) =>
     {
       make: () => {
@@ -17,19 +17,11 @@ let make = (~style: style=[], ~blendingMode, ~material, children) =>
         {view, layoutNode: Layout.Node.make(~style, view)};
       },
       configureInstance: (~isFirstRender as _, {view} as node) => {
-        switch (blendingMode) {
-        | Some(blendingMode) =>
-          BriskEffectView.setBlendingMode(view, blendingMode)
-        | _ => ()
-        };
-        switch (material) {
-        | Some(material) => BriskEffectView.setMaterial(view, material)
-        | _ => ()
-        };
         style
-        |> List.iter(attr =>
-             switch (attr) {
-             | #Styles.viewStyle => Styles.setViewStyle(view, attr)
+        |> List.iter(attribute =>
+             switch (attribute) {
+             | #BriskEffectView.style =>
+               BriskEffectView.setStyle(view, attribute)
              | #Layout.style => ()
              }
            );
@@ -39,5 +31,5 @@ let make = (~style: style=[], ~blendingMode, ~material, children) =>
     }
   );
 
-let createElement = (~style=[], ~children, ~blendingMode=?, ~material=?, ()) =>
-  element(make(~style, ~blendingMode, ~material, listToElement(children)));
+let createElement = (~style=[], ~children, ()) =>
+  element(make(~style, listToElement(children)));

--- a/renderer-macos/lib/dune
+++ b/renderer-macos/lib/dune
@@ -27,5 +27,7 @@
           BriskEffectView
           )
  (c_flags (:standard
-  (-Wextra -Wall -Werror -O -g -std=c99 -pedantic-errors -Wsign-compare -Wshadow -mmacosx-version-min=10.10)
-  (-x objective-c))))
+          -Wextra -Wall -Werror -O -g -std=c99 -pedantic-errors -Wsign-compare -Wshadow
+          -Wno-unguarded-availability-new
+          -mmacosx-version-min=10.10
+          -x objective-c)))

--- a/renderer-macos/lib/dune
+++ b/renderer-macos/lib/dune
@@ -24,7 +24,8 @@
           BriskImage
           BriskButton
           GCD
+          BriskEffectView
           )
  (c_flags (:standard
-  (-Wextra -Wall -Werror -O -g -std=c99 -pedantic-errors -Wsign-compare -Wshadow)
+  (-Wextra -Wall -Werror -O -g -std=c99 -pedantic-errors -Wsign-compare -Wshadow -mmacosx-version-min=10.10)
   (-x objective-c))))

--- a/renderer-macos/lib/stubs/BriskEffectView.c
+++ b/renderer-macos/lib/stubs/BriskEffectView.c
@@ -1,15 +1,12 @@
-#import "BriskCocoa.h"
 #import "Availability.h"
+#import "BriskCocoa.h"
 
-#define ACCESSOR(VALUE) \
-intnat ml_get##VALUE() {\
-  return VALUE;\
-} \
-\
-value ml_get##VALUE##_bc() {\
-  CAMLparam0(); \
-  CAMLreturn(VALUE);\
-}
+#define ACCESSOR(VALUE)                                                        \
+  intnat ml_get##VALUE() { return VALUE; }                                     \
+  value ml_get##VALUE##_bc() {                                                 \
+    CAMLparam0();                                                              \
+    CAMLreturn(VALUE);                                                         \
+  }
 
 #define VISUAL_EFFECT(VALUE) ACCESSOR(NSVisualEffectMaterial##VALUE)
 
@@ -17,11 +14,13 @@ value ml_get##VALUE##_bc() {\
 VISUAL_EFFECT(Titlebar)
 VISUAL_EFFECT(Selection)
 #endif
+
 #if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_11
 VISUAL_EFFECT(Menu)
 VISUAL_EFFECT(Popover)
 VISUAL_EFFECT(Sidebar)
 #endif
+
 #if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_14
 VISUAL_EFFECT(HeaderView)
 VISUAL_EFFECT(Sheet)
@@ -31,8 +30,8 @@ VISUAL_EFFECT(FullScreenUI)
 VISUAL_EFFECT(ToolTip)
 VISUAL_EFFECT(ContentBackground)
 VISUAL_EFFECT(UnderWindowBackground)
-VISUAL_EFFECT(PageBackground)
-VISUAL_EFFECT(AppeareanceBased)
+VISUAL_EFFECT(UnderPageBackground)
+VISUAL_EFFECT(AppearanceBased)
 #endif
 
 #define BLENDING_MODE(VALUE) ACCESSOR(NSVisualEffectBlendingMode##VALUE)
@@ -54,10 +53,12 @@ NSVisualEffectView *ml_NSVisualEffectView_make() {
   return view;
 }
 
-void ml_NSVisualEffectView_setMaterial(NSVisualEffectView *view, NSVisualEffectMaterial material) {
-    view.material = material;
+void ml_NSVisualEffectView_setMaterial(NSVisualEffectView *view,
+                                       NSVisualEffectMaterial material) {
+  view.material = material;
 }
 
-void ml_NSVisualEffectView_setBlendingMode(NSVisualEffectView *view, NSVisualEffectBlendingMode blendingMode) {
-    view.blendingMode = blendingMode;
+void ml_NSVisualEffectView_setBlendingMode(
+    NSVisualEffectView *view, NSVisualEffectBlendingMode blendingMode) {
+  view.blendingMode = blendingMode;
 }

--- a/renderer-macos/lib/stubs/BriskEffectView.c
+++ b/renderer-macos/lib/stubs/BriskEffectView.c
@@ -1,0 +1,63 @@
+#import "BriskCocoa.h"
+#import "Availability.h"
+
+#define ACCESSOR(VALUE) \
+intnat ml_get##VALUE() {\
+  return VALUE;\
+} \
+\
+value ml_get##VALUE##_bc() {\
+  CAMLparam0(); \
+  CAMLreturn(VALUE);\
+}
+
+#define VISUAL_EFFECT(VALUE) ACCESSOR(NSVisualEffectMaterial##VALUE)
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_10
+VISUAL_EFFECT(Titlebar)
+VISUAL_EFFECT(Selection)
+#endif
+#if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_11
+VISUAL_EFFECT(Menu)
+VISUAL_EFFECT(Popover)
+VISUAL_EFFECT(Sidebar)
+#endif
+#if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_14
+VISUAL_EFFECT(HeaderView)
+VISUAL_EFFECT(Sheet)
+VISUAL_EFFECT(WindowBackground)
+VISUAL_EFFECT(HUDWindow)
+VISUAL_EFFECT(FullScreenUI)
+VISUAL_EFFECT(ToolTip)
+VISUAL_EFFECT(ContentBackground)
+VISUAL_EFFECT(UnderWindowBackground)
+VISUAL_EFFECT(PageBackground)
+VISUAL_EFFECT(AppeareanceBased)
+#endif
+
+#define BLENDING_MODE(VALUE) ACCESSOR(NSVisualEffectBlendingMode##VALUE)
+BLENDING_MODE(BehindWindow)
+BLENDING_MODE(WithinWindow)
+
+#define BACKGROUND_STYLE(VALUE) ACCESSOR(NSBackgroundStyle##VALUE)
+BACKGROUND_STYLE(Raised)
+BACKGROUND_STYLE(Lowered)
+
+#define EFFECT_STATE(VALUE) ACCESSOR(NSVisualEffectState##VALUE)
+EFFECT_STATE(FollowsWindowActiveState)
+EFFECT_STATE(Active)
+EFFECT_STATE(Inactive)
+
+NSVisualEffectView *ml_NSVisualEffectView_make() {
+  NSVisualEffectView *view = [NSVisualEffectView new];
+  retainView(view);
+  return view;
+}
+
+void ml_NSVisualEffectView_setMaterial(NSVisualEffectView *view, NSVisualEffectMaterial material) {
+    view.material = material;
+}
+
+void ml_NSVisualEffectView_setBlendingMode(NSVisualEffectView *view, NSVisualEffectBlendingMode blendingMode) {
+    view.blendingMode = blendingMode;
+}

--- a/renderer-macos/lib/stubs/BriskEffectView.c
+++ b/renderer-macos/lib/stubs/BriskEffectView.c
@@ -9,6 +9,8 @@
   }
 
 #define VISUAL_EFFECT(VALUE) ACCESSOR(NSVisualEffectMaterial##VALUE)
+#define BLENDING_MODE(VALUE) ACCESSOR(NSVisualEffectBlendingMode##VALUE)
+#define EFFECT_STATE(VALUE) ACCESSOR(NSVisualEffectState##VALUE)
 
 #if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_10
 VISUAL_EFFECT(Titlebar)
@@ -34,15 +36,9 @@ VISUAL_EFFECT(UnderPageBackground)
 VISUAL_EFFECT(AppearanceBased)
 #endif
 
-#define BLENDING_MODE(VALUE) ACCESSOR(NSVisualEffectBlendingMode##VALUE)
 BLENDING_MODE(BehindWindow)
 BLENDING_MODE(WithinWindow)
 
-#define BACKGROUND_STYLE(VALUE) ACCESSOR(NSBackgroundStyle##VALUE)
-BACKGROUND_STYLE(Raised)
-BACKGROUND_STYLE(Lowered)
-
-#define EFFECT_STATE(VALUE) ACCESSOR(NSVisualEffectState##VALUE)
 EFFECT_STATE(FollowsWindowActiveState)
 EFFECT_STATE(Active)
 EFFECT_STATE(Inactive)
@@ -61,4 +57,22 @@ void ml_NSVisualEffectView_setMaterial(NSVisualEffectView *view,
 void ml_NSVisualEffectView_setBlendingMode(
     NSVisualEffectView *view, NSVisualEffectBlendingMode blendingMode) {
   view.blendingMode = blendingMode;
+}
+
+void ml_NSVisualEffectView_setEmphasized(NSVisualEffectView *view,
+                                         intnat emphasized) {
+  view.emphasized = (BOOL)emphasized;
+}
+
+CAMLprim value ml_NSVisualEffectView_setEmphasized_bc(NSVisualEffectView *view,
+                                                      value emphasized_v) {
+  CAMLparam1(emphasized_v);
+  ml_NSVisualEffectView_setEmphasized(view, Int_val(emphasized_v));
+
+  CAMLreturn(Val_unit);
+}
+
+void ml_NSVisualEffectView_setEffectState(NSVisualEffectView *view,
+                                          NSVisualEffectState state) {
+  view.state = state;
 }


### PR DESCRIPTION
This PR adds support for fancy translucent elements binding to `NSVisualEffectView`.

Current issues:

- [x] When we explicitly set `NSRequiresAquaSystemAppearance` (light mode), it doesn't add translucency
- [x] In light mode, with system-wide appearance settings, `Button` doesn't have a translucency even if it's a child of `EffectView`. (in dark mode, it correctly blends with the bg)

Turns out, those are non-issues as it's AppKit being smart and not adding blending where it's not needed.