### PR TITLE
Set clickable callback on configureInstance

### DIFF
--- a/renderer-macos/lib/bindings/BriskClickable.re
+++ b/renderer-macos/lib/bindings/BriskClickable.re
@@ -6,13 +6,6 @@ type t = CocoaTypes.view;
 external setOnClick: (t, unit => unit) => unit =
   "ml_BriskClickable_setOnClick";
 
-let make = (~onClick=?, ()) => {
-  let btn = make();
-
-  switch (onClick) {
-  | Some(callback) => setOnClick(btn, UIEventCallback.make(callback))
-  | None => ()
-  };
-
-  btn;
+let setOnClick = (btn, callback) => {
+  setOnClick(btn, UIEventCallback.make(callback));
 };

--- a/renderer-macos/lib/components/Clickable.re
+++ b/renderer-macos/lib/components/Clickable.re
@@ -17,13 +17,15 @@ let component = {
         hooks,
         {
           make: () => {
-            let view = BriskClickable.make(~onClick, ());
+            let view = BriskClickable.make();
             let layoutNode =
               Layout.Node.make(~style, {view, isYAxisFlipped: false});
 
             {view, layoutNode};
           },
           configureInstance: (~isFirstRender as _, {view} as node) => {
+            BriskClickable.setOnClick(view, onClick);
+
             style
             |> List.iter(attribute =>
                  switch (attribute) {


### PR DESCRIPTION
This fixes the issue when `setState` hook on the button callback worked only once because we were setting onClick only at the creation of the node.