### PR TITLE
Link gmp statically

### DIFF
--- a/examples/hacker-news/macos_app_bundle/dune
+++ b/examples/hacker-news/macos_app_bundle/dune
@@ -3,6 +3,8 @@
  (action (with-stdout-to %{targets} (progn
   (echo "STDLIB_PATH=%{ocaml_where}\n")
   (echo "BUILD_PATH=%{workspace_root}\n")
+  (bash "echo ESY_LIBRARY_SEARCH_PATHS=$(pkg-config gmp --variable=libdir)")
+  (bash "echo ESY_LINK_FLAGS=$(pkg-config gmp --libs-only-l)")
  ))))
 
 (rule

--- a/examples/hacker-news/macos_app_bundle/dune
+++ b/examples/hacker-news/macos_app_bundle/dune
@@ -3,8 +3,6 @@
  (action (with-stdout-to %{targets} (progn
   (echo "STDLIB_PATH=%{ocaml_where}\n")
   (echo "BUILD_PATH=%{workspace_root}\n")
-  (bash "echo ESY_LIBRARY_SEARCH_PATHS=$(pkg-config gmp --variable=libdir)")
-  (bash "echo ESY_LINK_FLAGS=$(pkg-config gmp --libs-only-l)")
  ))))
 
 (rule

--- a/examples/hacker-news/macos_app_bundle/project.yml
+++ b/examples/hacker-news/macos_app_bundle/project.yml
@@ -18,13 +18,10 @@ targets:
     sources:
       - Resources
       - Sources
-      - path: /Users/wczekalski/.esy/3______________________________________________________________/i/gmp-86f60d0f/lib/libgmp.dylib
-        buildPhase:
-          copyFiles:
-            destination: frameworks
     settings:
-      HEADER_SEARCH_PATHS: "$(STDLIB_PATH)"
-      OTHER_LDFLAGS: "-framework Cocoa"
+      HEADER_SEARCH_PATHS: '$(STDLIB_PATH)'
+      LIBRARY_SEARCH_PATHS: '$(ESY_LIBRARY_SEARCH_PATHS)'
+      OTHER_LDFLAGS: '-framework Cocoa -Wl,-no_pie $(ESY_LINK_FLAGS)'
     configFiles:
       Debug: env.xcconfig
       Release: env.xcconfig

--- a/examples/hacker-news/macos_app_bundle/project.yml
+++ b/examples/hacker-news/macos_app_bundle/project.yml
@@ -18,10 +18,13 @@ targets:
     sources:
       - Resources
       - Sources
+      - path: /Users/wczekalski/.esy/3______________________________________________________________/i/gmp-86f60d0f/lib/libgmp.dylib
+        buildPhase:
+          copyFiles:
+            destination: frameworks
     settings:
       HEADER_SEARCH_PATHS: "$(STDLIB_PATH)"
-      LIBRARY_SEARCH_PATHS: "$(ESY_LIBRARY_SEARCH_PATHS)"
-      OTHER_LDFLAGS: "-framework Cocoa $(ESY_LINK_FLAGS)"
+      OTHER_LDFLAGS: "-framework Cocoa"
     configFiles:
       Debug: env.xcconfig
       Release: env.xcconfig


### PR DESCRIPTION
@rauanmayemir this might need another sweep. We should either link everything statically or do it like this. Is there a way to package zarith in such a way that I, as a user of a dependency which transitively depends on zarith, can chose to link it either statically or dynamically?