### PR TITLE
Fix Scroll View to apply style to its outer container

### DIFF
--- a/examples/hacker-news/app/StoryList.re
+++ b/examples/hacker-news/app/StoryList.re
@@ -1,7 +1,9 @@
+open Brisk_macos;
+
 type stories =
   array([ | `Poll(Story.poll) | `Story(Story.story) | `Job(Story.job)]);
 
-let backgroundColor = Brisk_macos.Brisk.Layout.(background(Color.hex("#FFFFFF")));
+let backgroundColor = Brisk.Layout.(background(Color.hex("#FFFFFF")));
 
 let story =
     (
@@ -11,47 +13,44 @@ let story =
       ~children as _: list(unit),
       (),
     ) =>
-  Brisk_macos.(
-    Brisk.Layout.(
-      <clickable
-        onClick style=[height(47.), backgroundColor]>
-        <view style=[alignItems(`Center), flexDirection(`Row)]>
-          <text
-            style=[
-              height(20.),
-              width(30.),
-              align(`Center),
-              font(~size=13., ()),
-              color(Color.hex("#B0B0B0")),
-            ]
-            value={string_of_int(index)}
-          />
-          <view style=[flex(1.)]>
-            <view style=[flexDirection(`Row)]>
-              <text
-                style=[
-                  flex(1.),
-                  font(~size=13., ()),
-                  lineBreak(`TruncateTail),
-                  color(Color.hex("#000000")),
-                ]
-                value={story.title}
-              />
-            </view>
+  Brisk.Layout.(
+    <clickable onClick style=[height(47.), backgroundColor]>
+      <view style=[alignItems(`Center), flexDirection(`Row)]>
+        <text
+          style=[
+            height(20.),
+            width(30.),
+            align(`Center),
+            font(~size=13., ()),
+            color(Color.hex("#B0B0B0")),
+          ]
+          value={string_of_int(index)}
+        />
+        <view style=[flex(1.)]>
+          <view style=[flexDirection(`Row)]>
             <text
-              style=[color(Color.hex("#888888"))]
-              value={Story.formatDetails(
-                ~username=story.by.id,
-                ~score=story.score,
-                ~commentCount=story.descendants,
-                ~url=story.url,
-              )}
+              style=[
+                flex(1.),
+                font(~size=13., ()),
+                lineBreak(`TruncateTail),
+                color(Color.hex("#000000")),
+              ]
+              value={story.title}
             />
           </view>
-          <text value=timeAgo />
+          <text
+            style=[color(Color.hex("#888888"))]
+            value={Story.formatDetails(
+              ~username=story.by.id,
+              ~score=story.score,
+              ~commentCount=story.descendants,
+              ~url=story.url,
+            )}
+          />
         </view>
-      </clickable>
-    )
+        <text value=timeAgo />
+      </view>
+    </clickable>
   );
 
 let getStories = hn =>
@@ -99,7 +98,6 @@ let fetchStories =
 };
 
 let component = {
-  open Brisk_macos;
   open Core_kernel.Sequence;
   open Brisk.Layout;
   let component = Brisk.component("StoryList");
@@ -116,30 +114,26 @@ let component = {
       (
         hooks,
         <scrollView
-          onReachedEnd=loadNextPage
-          style=[flex(1.), backgroundColor]>
-          {
-               switch (stories) {
-               | Loading =>
-                 <activityIndicator style=[flex(1.)] />
-               | stories =>
-                 stories
-                 |> Paging.getResultList
-                 |> List.rev
-                 |> of_list
-                 |> map(~f=of_list)
-                 |> concat
-                 |> mapi(~f=(index, astory) =>
-                      <story
-                        story=astory
-                        index={index + 1}
-                        onClick={() => showDetails(astory)}
-                      />
-                    )
-                 |> to_list
-                 |> Brisk.listToElement
-               }
-             }
+          onReachedEnd=loadNextPage style=[flex(1.), backgroundColor]>
+          {switch (stories) {
+           | Loading => <activityIndicator style=[flex(1.)] />
+           | stories =>
+             stories
+             |> Paging.getResultList
+             |> List.rev
+             |> of_list
+             |> map(~f=of_list)
+             |> concat
+             |> mapi(~f=(index, astory) =>
+                  <story
+                    story=astory
+                    index={index + 1}
+                    onClick={() => showDetails(astory)}
+                  />
+                )
+             |> to_list
+             |> Brisk.listToElement
+           }}
         </scrollView>,
       );
     });

--- a/examples/hacker-news/app/StoryList.re
+++ b/examples/hacker-news/app/StoryList.re
@@ -1,6 +1,8 @@
 type stories =
   array([ | `Poll(Story.poll) | `Story(Story.story) | `Job(Story.job)]);
 
+let backgroundColor = Brisk_macos.Brisk.Layout.(background(Color.hex("#FFFFFF")));
+
 let story =
     (
       ~story as {Story.story, timeAgo},
@@ -12,7 +14,7 @@ let story =
   Brisk_macos.(
     Brisk.Layout.(
       <clickable
-        onClick style=[height(47.), background(Color.hex("#FFFFFF"))]>
+        onClick style=[height(47.), backgroundColor]>
         <view style=[alignItems(`Center), flexDirection(`Row)]>
           <text
             style=[
@@ -115,7 +117,7 @@ let component = {
         hooks,
         <scrollView
           onReachedEnd=loadNextPage
-          style=[flex(1.), background(Color.hex("#fff"))]>
+          style=[flex(1.), backgroundColor]>
           {
                switch (stories) {
                | Loading =>

--- a/renderer-macos/lib/components/ScrollView.re
+++ b/renderer-macos/lib/components/ScrollView.re
@@ -118,9 +118,9 @@ let component =
   let scrollStyle = [flex(1.)];
   let contentStyle = [position(~top=0., ~left=0., ~right=0., `Absolute)];
 
-  <view style=scrollStyle>
+  <view style=style>
     <scrollableArea onScroll onReachedEnd style=scrollStyle contentStyle>
-      <view style> ...children </view>
+      <view style=scrollStyle> ...children </view>
     </scrollableArea>
   </view>;
 };


### PR DESCRIPTION
There are two problems with the current (`master`) implementation of scroll view:

1. The container is always `flex(1.)` so effectively it's impossible for the user to control the layout of  their components when they use scroll view
2. The styling (like color, border) is only applied to the inner view which fits the content size.