### PR TITLE
Update README: full Xcode installation is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,9 @@ npm -g i esy@next
 
 ### macOS
 
-##### XCode
+##### Xcode
 
-Install `Command Line Tools`.
-
-```
-xcode-select --install
-```
+In order to build the OSX binary you will need to install [`Xcode`](https://developer.apple.com/xcode/).
 
 ### Other Platforms
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ npm -g i esy@next
 
 ##### Xcode
 
-In order to build the OSX binary you will need to install [`Xcode`](https://developer.apple.com/xcode/).
+In order to build the OSX binary you will need to install [`Xcode`](https://developer.apple.com/xcode/), as well as `Command Line Tools`:
+
+```
+xcode-select --install
+```
 
 ### Other Platforms
 


### PR DESCRIPTION
I had just the command line tools installed on my machine, and I got this error message:

```
Done: 79/83 (jobs: 1)xcode-select: error: tool 'xcodebuild' requires Xcode, 
but active developer directory '/Library/Developer/CommandLineTools' is a 
command line tools instance
```